### PR TITLE
Migrate MSAL iOS wiki

### DIFF
--- a/msal-objc-articles/Cloud-instance-discovery-(instance-aware-flow).md
+++ b/msal-objc-articles/Cloud-instance-discovery-(instance-aware-flow).md
@@ -1,0 +1,30 @@
+Some apps might need to work with multiple cloud instances at the same time depending on the account.
+In that case, instance aware flow might be useful.
+
+Instance aware flow allows to perform sovereign cloud discovery in MSAL. This feature is supported end to end only for Microsoft internal services. 
+
+If developer wants to support discovery of accounts from sovereign cloud, e.g. German cloud Blackforest, Chinese cloud Mooncake, etc., two things need to be done:
+
+1. The following parameter must be passed as extra query parameter for the interactive acquire token call:
+
+   `instance_aware : true`
+
+Note: Undefined behavior might happen if user tries to log in an account from sovereign cloud using a worldwide authority.
+
+```
+NSDictionary *extraQueryParameters = @{@"instance_aware":@"true"};
+
+[application acquireTokenForScopes:kScopes
+                         loginHint:nil
+                        uiBehavior:MSALUIBehaviorDefault
+             extraQueryParameters:extraQueryParameters
+                  completionBlock:^(MSALResult *result, NSError *error) {
+            // Handle result
+}];
+```
+
+Note: you might need to pass a different set of scopes for each sovereign cloud. The specific set of scopes depends on the resource that you're using. For example, you could use "https://graph.microsoft.com/user.read" in worldwide cloud, and "https://graph.microsoft.de/user.read" in German cloud.
+
+2. There will be an `authority` property in the `MSALResult` returned in the above call. It may be different from the authority provided by developer. 
+
+Developer should use such an `authority` for subsequent silent acquire token call. Otherwise, cached result might be not found in subsequent calls. 

--- a/msal-objc-articles/Configuring-your-app.md
+++ b/msal-objc-articles/Configuring-your-app.md
@@ -1,0 +1,1 @@
+This article was migrated to [docs.microsoft.com](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-ios)

--- a/msal-objc-articles/Home.md
+++ b/msal-objc-articles/Home.md
@@ -1,0 +1,41 @@
+The Objective-C Microsoft Authentication Library (MSAL) is an Auth SDK that can be used to seamlessly integrate authentication into your app and give access to the entire Microsoft ecosystem. 
+
+This platform allows you to easily target several identities including Azure AD (Work and School accounts), Microsoft account (Outlook.com, hotmail.com, and several others), or Azure AD B2C (Social and Local accounts). 
+Your app will then have access to the entire set of Microsoft cloud APIs including the Microsoft Graph, Office 365, Azure, and any API you want to protect.  
+
+The wiki is intended to document common patterns, error handling & debugging best practices, extra library functionality (e.g. logging, telemetry), and any active bugs or common issues with known mitigations. If you're looking for more help getting started with Azure AD, Microsoft Accounts, or Azure AD B2C, check out the full [Microsoft identity platform docs](https://aka.ms/aaddev). If you're looking for more info about the Microsoft Graph API, check out the [Microsoft Graph docs](https://graph.microsoft.io).
+
+This wiki will be evolving over time. If you have a question about MSAL SDK, found an error in the documentation or need a recommendation on, please create a [Github issue](https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues) with the details!
+
+### Getting started with MSAL SDK
+- [Home](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki)
+- [Register your app](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-register-an-app)
+- [Getting Started](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-ios) 
+- [MSAL Code Sample](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-ios#step-2-download-the-sample-project)
+- [Single Sign-on (SSO)](https://docs.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-macos-ios)
+- [Error Handling](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-handling-exceptions#msal-for-ios-and-macos-errors)
+
+### Configure, Build, Test, Deploy
+- [Installation](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki/Installation)
+- [Configuring your app](https://github.com/AzureAD/microsoft-authentication-library-for-objc/tree/master#configuring-msal)
+- [Targeting different identity types](https://docs.microsoft.com/en-us/azure/active-directory/develop/config-authority)
+
+### Advanced Topics
+- [Customizing Browsers and WebViews](https://docs.microsoft.com/en-us/azure/active-directory/develop/customize-webviews)
+- [Logging](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-logging#logging-in-msal-for-ios-and-macos)
+- [Sovereign clouds](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-national-cloud)
+- [B2C](https://docs.microsoft.com/en-us/azure/active-directory/develop/config-authority#b2c)
+
+### Getting Help, Common Issues, and FAQ
+
+- [Redirect URIs](https://docs.microsoft.com/en-us/azure/active-directory/develop/redirect-uris-ios)
+- [Requesting individual claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/request-custom-claims)
+- [Keychain cache](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-v2-keychain-objc)
+- [SSL issues](https://docs.microsoft.com/en-us/azure/active-directory/develop/ssl-issues)
+- [iOS 13 and macOS 10.15 support](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki/iOS-13-and-macOS-10.15-support-in-MSAL)
+
+### Migrating
+- [ADAL to MSAL](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-objc-adal-msal)
+
+### News
+- [Releases](https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases)

--- a/msal-objc-articles/Installation.md
+++ b/msal-objc-articles/Installation.md
@@ -1,0 +1,95 @@
+## Installation
+ 
+### Using CocoaPods
+
+#### Installing CocoaPods
+[CocoaPods](https://cocoapods.org) is a dependency manager for Swift and Objective-C Cocoa projects.
+It can be installed as a ruby gem, by using the following command.
+```
+$ sudo gem install cocoapods
+```
+> Depending on your Ruby setup, `sudo` may or may not be needed.
+
+#### Include MSAL in Podfile
+Create a new `Podfile` or add to the existing podfile, include `pod 'MSAL'` under `target. 
+
+An example Podfile:
+```
+target "your-target-here" do
+    pod 'MSAL'
+end
+```
+
+Note: if you're checking out a particular branch or tag of MSAL, you will need to add the :submodules => true flag to your podfile, so that CocoaPods finds MSAL dependencies
+
+```
+pod 'MSAL', :git => 'https://github.com/AzureAD/microsoft-authentication-library-for-objc', :branch => 'master', :submodules => true
+```
+
+You then you can run either `pod install` (if it's a new PodFile) or `pod update` (if it's an existing PodFile) to get the latest version of MSAL. 
+
+Subsequent calls to `pod update` will update to the latest released version of MSAL as well.
+
+See [CocoaPods](https://guides.cocoapods.org/using/the-podfile.html) for more information on setting up a PodFile
+
+### Using Carthage
+
+[Carthage](https://github.com/Carthage/Carthage) is another popular dependency manager MSAL supports. 
+The following is a sample using Carthage.
+
+##### If you're building for iOS, tvOS, or watchOS
+
+1. Install Carthage on your Mac using a download from their website or if using Homebrew `brew install carthage`.
+1. You must create a `Cartfile` that lists the MSAL library for this project on Github. 
+
+```
+github "AzureAD/microsoft-authentication-library-for-objc" "master"
+```
+Note: this will point Carthage to the master branch, so you'll always get the latest official release. If you would like to use a particular version, you can do the following:
+
+```
+github "AzureAD/microsoft-authentication-library-for-objc" == <latest_released_version>
+```
+
+1. Run `carthage update`. This will fetch dependencies into a `Carthage/Checkouts` folder, then build the MSAL library.
+1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop the `MSAL.framework` from the `Carthage/Build` folder on disk.
+1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
+
+  ```sh
+  /usr/local/bin/carthage copy-frameworks
+  ```
+
+  and add the paths to the frameworks you want to use under “Input Files”, e.g.:
+
+  ```
+  $(SRCROOT)/Carthage/Build/iOS/MSAL.framework
+  ```
+  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
+
+With the debug information copied into the built products directory, Xcode will be able to symbolicate the stack trace whenever you stop at a breakpoint. This will also enable you to step through third-party code in the debugger.
+
+When archiving your application for submission to the App Store or TestFlight, Xcode will also copy these files into the dSYMs subdirectory of your application’s `.xcarchive` bundle.
+
+### Manually
+
+1. Check out the repository using the following command.
+```
+git clone https://github.com/AzureAD/microsoft-authentication-library-for-objc.git --recursive
+```
+
+2. In your project, drag and add `microsoft-authentication-library-for-objc/MSAL/MSAL.xcodeproj`
+3. In your project settings, for the target application, select `Build Phases` and add MSAL in `Target Dependencies`.
+
+### Using Git Submodule
+
+If your project is managed in a git repository you can include MSAL as a git submodule. First check the GitHub Releases Page for the latest release tag. Replace <latest_release_tag> with that version.
+
+* `git submodule add https://github.com/AzureAD/microsoft-authentication-library-for-objc msal`
+* `cd msal`
+* `git checkout tags/<latest_release_tag>`
+* `git submodule update --init --recursive`
+* `cd ..`
+* `git add msal`
+* `git commit -m "Use MSAL git submodule at <latest_release_tag>"`
+* `git push`
+

--- a/msal-objc-articles/SSL-issues.md
+++ b/msal-objc-articles/SSL-issues.md
@@ -1,0 +1,43 @@
+---
+title: Troubleshoot TLS/SSL issues (MSAL iOS/macOS)
+description: Learn what to do about various problems using TLS/SSL certificates with the MSAL.Objective-C library.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.workload: identity
+ms.topic: conceptual
+ms.date: 08/28/2019
+ms.author: owenrichards
+ms.custom: aaddev
+---
+
+# Troubleshoot MSAL for iOS and macOS TLS/SSL issues
+
+This article provides information to help you troubleshoot issues that you may come across while using the [Microsoft Authentication Library (MSAL) for iOS and macOS](reference-v2-libraries.md)
+
+## Network issues
+
+**Error -1200**: "An SSL error has occurred and a secure connection to the server can't be made."
+
+This error means that the connection isn't secure. It occurs when a certificate is invalid. For more information, including which server is failing the TLS check, refer to `NSURLErrorFailingURLErrorKey` in the `userInfo` dictionary of the error object.
+
+This error is from Apple's networking library. A full list of NSURL error codes is in NSURLError.h in the macOS and iOS SDKs. For more details about this error, see [URL Loading System Error Codes](https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes?language=objc).
+
+## Certificate issues
+
+If the URL providing an invalid certificate connects to the server that you intend to use as part of the authentication flow, a good start to diagnosing the problem is to test the URL with an SSL validation service such as [SSL Server Test](https://www.ssllabs.com/ssltest/analyze.html). It tests the server against a wide array of scenarios and browsers and checks for many known vulnerabilities.
+
+By default, Apple's new [App Transport Security (ATS)](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35) feature applies more stringent security policies to apps that use TLS/SSL certificates. Some operating systems and web browsers have started enforcing some of these policies by default. For security reasons, we recommend you not disable ATS.
+
+Certificates using SHA-1 hashes have known vulnerabilities. Most modern web browsers don't allow certificates with SHA-1 hashes.
+
+## Captive portals
+
+A captive portal presents a web page to a user when they first access a Wi-Fi network and haven't yet been granted access to that network. It intercepts their internet traffic until the user satisfies the requirements of the portal. Network errors because the user can't connect to network resources are expected until the user connects through the portal.
+
+## Next steps
+
+Learn about [captive portals](https://en.wikipedia.org/wiki/Captive_portal) and Apple's new [App Transport Security (ATS)](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35) feature.

--- a/msal-objc-articles/TOC.yml
+++ b/msal-objc-articles/TOC.yml
@@ -1,2 +1,6 @@
-- name: Index
-  href: index.md
+- name: Microsoft Authentication Library for iOS and macOS
+  items:
+  - name: Getting started
+    items:
+    - name: Overview
+      href: index.md

--- a/msal-objc-articles/configure-authority.md
+++ b/msal-objc-articles/configure-authority.md
@@ -1,0 +1,250 @@
+---
+title: Configure identity providers (MSAL iOS/macOS)
+description: Learn how to use different authorities such as B2C, sovereign clouds, and guest users, with MSAL for iOS and macOS.
+services: active-directory
+author: cilwerner
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.workload: identity
+ms.topic: conceptual
+ms.date: 05/09/2023
+ms.author: cwerner
+ms.reviewer: oldalton
+ms.custom: aaddev
+---
+
+# Configure MSAL for iOS and macOS to use different identity providers
+
+This article will show you how to configure your Microsoft Authentication Library app for iOS and macOS (MSAL) for different authorities such as Microsoft Entra ID, Business-to-Consumer (B2C), sovereign clouds, and guest users.  Throughout this article, you can generally think of an authority as an identity provider.
+
+## Default authority configuration
+
+`MSALPublicClientApplication` is configured with a default authority URL of `https://login.microsoftonline.com/common`, which is suitable for most Microsoft Entra scenarios. Unless you're implementing advanced scenarios like national clouds, or working with B2C, you won't need to change it.
+
+> [!NOTE]
+> Modern authentication with Active Directory Federation Services as identity provider (ADFS) is not supported (see [ADFS for Developers](/windows-server/identity/ad-fs/overview/ad-fs-openid-connect-oauth-flows-scenarios) for details). ADFS is supported through federation.
+
+## Change the default authority
+
+In some scenarios, such as business-to-consumer (B2C), you may need to change the default authority.
+
+### B2C
+
+To work with B2C, the [Microsoft Authentication Library (MSAL)](reference-v2-libraries.md) requires a different authority configuration. MSAL recognizes one authority URL format as B2C by itself. The recognized B2C authority format is `https://<host>/tfp/<tenant>/<policy>`, for example `https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_SignInPolicy`. However, you can also use any other supported B2C authority URLs by declaring authority as B2C authority explicitly.
+
+To support an arbitrary URL format for B2C, `MSALB2CAuthority` can be set with an arbitrary URL, like this:
+
+Objective-C
+```objc
+NSURL *authorityURL = [NSURL URLWithString:@"arbitrary URL"];
+MSALB2CAuthority *b2cAuthority = [[MSALB2CAuthority alloc] initWithURL:authorityURL
+                                                                     error:&b2cAuthorityError];
+```
+Swift
+```swift
+guard let authorityURL = URL(string: "arbitrary URL") else {
+    // Handle error
+    return
+}
+let b2cAuthority = try MSALB2CAuthority(url: authorityURL)
+```
+
+All B2C authorities that don't use the default B2C authority format must be declared as known authorities.
+
+Add each different B2C authority to the known authorities list even if authorities only differ in policy.
+
+Objective-C
+```objc
+MSALPublicClientApplicationConfig *b2cApplicationConfig = [[MSALPublicClientApplicationConfig alloc]
+                                                               initWithClientId:@"your-client-id"
+                                                               redirectUri:@"your-redirect-uri"
+                                                               authority:b2cAuthority];
+b2cApplicationConfig.knownAuthorities = @[b2cAuthority];
+```
+Swift
+```swift
+let b2cApplicationConfig = MSALPublicClientApplicationConfig(clientId: "your-client-id", redirectUri: "your-redirect-uri", authority: b2cAuthority)
+b2cApplicationConfig.knownAuthorities = [b2cAuthority]
+```
+
+When your app requests a new policy, the authority URL needs to be changed because the authority URL is different for each policy. 
+
+To configure a B2C application, set `@property MSALAuthority *authority` with an instance of `MSALB2CAuthority` in `MSALPublicClientApplicationConfig` before creating `MSALPublicClientApplication`, like this:
+
+Objective-C
+```ObjC
+    // Create B2C authority URL
+    NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_SignInPolicy"];
+    
+    MSALB2CAuthority *b2cAuthority = [[MSALB2CAuthority alloc] initWithURL:authorityURL
+                                                                     error:&b2cAuthorityError];
+    if (!b2cAuthority)
+    {
+        // Handle error
+        return;
+    }
+    
+    // Create MSALPublicClientApplication configuration
+    MSALPublicClientApplicationConfig *b2cApplicationConfig = [[MSALPublicClientApplicationConfig alloc]
+                                                                   initWithClientId:@"your-client-id"
+                                                                   redirectUri:@"your-redirect-uri"
+                                                                   authority:b2cAuthority];
+
+    // Initialize MSALPublicClientApplication
+    MSALPublicClientApplication *b2cApplication =
+    [[MSALPublicClientApplication alloc] initWithConfiguration:b2cApplicationConfig error:&error];
+    
+    if (!b2cApplication)
+    {
+        // Handle error
+        return;
+    }
+```
+Swift
+```swift
+do{
+    // Create B2C authority URL
+    guard let authorityURL = URL(string: "https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_SignInPolicy") else {
+        // Handle error
+        return
+    }
+    let b2cAuthority = try MSALB2CAuthority(url: authorityURL)
+
+    // Create MSALPublicClientApplication configuration
+    let b2cApplicationConfig = MSALPublicClientApplicationConfig(clientId: "your-client-id", redirectUri: "your-redirect-uri", authority: b2cAuthority)
+
+    // Initialize MSALPublicClientApplication
+    let b2cApplication = try MSALPublicClientApplication(configuration: b2cApplicationConfig)
+} catch {
+    // Handle error
+}
+```
+
+### Sovereign clouds
+
+If your app runs in a sovereign cloud, you may need to change the authority URL in the `MSALPublicClientApplication`. The following example sets the authority URL to work with the German Microsoft Entra cloud:
+
+Objective-C
+```objc
+    NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.de/common"];
+    MSALAuthority *sovereignAuthority = [MSALAuthority authorityWithURL:authorityURL error:&authorityError];
+    
+    if (!sovereignAuthority)
+    {
+        // Handle error
+        return;
+    }
+    
+    MSALPublicClientApplicationConfig *applicationConfig = [[MSALPublicClientApplicationConfig alloc]
+                                                               initWithClientId:@"your-client-id"
+                                                               redirectUri:@"your-redirect-uri"
+                                                               authority:sovereignAuthority];
+    
+    
+    MSALPublicClientApplication *sovereignApplication = [[MSALPublicClientApplication alloc] initWithConfiguration:applicationConfig error:&error];
+    
+    
+    if (!sovereignApplication)
+    {
+        // Handle error
+        return;
+    }
+```
+Swift
+```swift
+do{
+    guard let authorityURL = URL(string: "https://login.microsoftonline.de/common") else {
+        //Handle error
+        return
+    }
+    let sovereignAuthority = try MSALAuthority(url: authorityURL)
+            
+    let applicationConfig = MSALPublicClientApplicationConfig(clientId: "your-client-id", redirectUri: "your-redirect-uri", authority: sovereignAuthority)
+            
+    let sovereignApplication = try MSALPublicClientApplication(configuration: applicationConfig)
+} catch {
+    // Handle error
+}
+```
+
+You may need to pass different scopes to each sovereign cloud. Which scopes to send depends on the resource that you're using. For example, you might use `"https://graph.microsoft.com/user.read"` in worldwide cloud, and `"https://graph.microsoft.de/user.read"` in German cloud.
+
+### Signing a user into a specific tenant
+
+When the authority URL is set to `"login.microsoftonline.com/common"`, the user will be signed into their home tenant. However, some apps may need to sign the user into a different tenant and some apps only work with a single tenant.
+
+To sign the user into a specific tenant, configure `MSALPublicClientApplication` with a specific authority. For example:
+
+`https://login.microsoftonline.com/dddd5555-eeee-6666-ffff-00001111aaaa`
+
+If you want to sign into the Contoso tenant, use;
+
+`https://login.microsoftonline.com/contoso.onmicrosoft.com`
+
+The following shows how to sign a user into the Contoso tenant:
+
+Objective-C
+```objc
+    NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.onmicrosoft.com"];
+    MSALAADAuthority *tenantedAuthority = [[MSALAADAuthority alloc] initWithURL:authorityURL error:&authorityError];
+    
+    if (!tenantedAuthority)
+    {
+        // Handle error
+        return;
+    }
+    
+    MSALPublicClientApplicationConfig *applicationConfig = [[MSALPublicClientApplicationConfig alloc]
+                                                               initWithClientId:@"your-client-id"
+                                                               redirectUri:@"your-redirect-uri"
+                                                               authority:tenantedAuthority];
+    
+    MSALPublicClientApplication *application =
+    [[MSALPublicClientApplication alloc] initWithConfiguration:applicationConfig error:&error];
+    
+    if (!application)
+    {
+        // Handle error
+        return;
+    }
+```
+Swift
+```swift
+do{
+    guard let authorityURL = URL(string: "https://login.microsoftonline.com/contoso.onmicrosoft.com") else {
+        //Handle error
+        return
+    }    
+    let tenantedAuthority = try MSALAADAuthority(url: authorityURL)
+            
+    let applicationConfig = MSALPublicClientApplicationConfig(clientId: "your-client-id", redirectUri: "your-redirect-uri", authority: tenantedAuthority)
+            
+    let application = try MSALPublicClientApplication(configuration: applicationConfig)
+} catch {
+    // Handle error
+}
+```
+
+## Supported authorities
+
+### MSALAuthority
+
+The `MSALAuthority` class is the base abstract class for the MSAL authority classes. Don't try to create instance of it using `alloc` or `new`. Instead, either create one of its subclasses directly (`MSALAADAuthority`, `MSALB2CAuthority`) or use the factory method `authorityWithURL:error:` to create subclasses using an authority URL.
+
+Use the `url` property to get a normalized authority URL. Extra parameters and path components or fragments that aren't part of authority won't be in the returned normalized authority URL.
+
+The following are subclasses of `MSALAuthority` that you can instantiate depending on the authority want to use.
+
+### MSALAADAuthority
+
+`MSALAADAuthority` represents a Microsoft Entra authority. The authority URL should be in the following format, where `<port>` is optional: `https://<host>:<port>/<tenant>`
+
+### MSALB2CAuthority
+
+`MSALB2CAuthority` represents a B2C authority. By default, the B2C authority URL should be in the following format, where `<port>` is optional: `https://<host>:<port>/tfp/<tenant>/<policy>`. However, MSAL also supports other arbitrary B2C authority formats.
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/customize-webviews.md
+++ b/msal-objc-articles/customize-webviews.md
@@ -1,0 +1,174 @@
+---
+title: Customize browsers & WebViews (MSAL iOS/macOS)
+description: Learn how to customize the MSAL iOS/macOS browser experience to sign in users.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 01/24/2023
+ms.author: henrymbugua
+ms.reviewer: oldalton
+ms.custom: aaddev, has-adal-ref
+---
+
+# Customize browsers and WebViews for iOS/macOS
+
+A web browser is required for interactive authentication. On iOS and macOS 10.15+, the Microsoft Authentication Library (MSAL) uses the system web browser by default (which might appear on top of your app) to do interactive authentication to sign in users. Using the system browser has the advantage of sharing the single sign-on (SSO) state with other applications and with web applications.
+
+You can change the experience by customizing the configuration to other options for displaying web content, such as:
+
+For iOS only:
+
+- [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession?language=objc)
+- [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller?language=objc)
+
+For iOS and macOS:
+
+- [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession?language=objc)
+- [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview?language=objc).
+
+MSAL for macOS only supports `WKWebView` on older OS versions. `ASWebAuthenticationSession` is only supported on macOS 10.15 and above.
+
+## System browsers
+
+For iOS, `ASWebAuthenticationSession`, `SFAuthenticationSession`, and `SFSafariViewController` are considered system browsers. For macOS, only `ASWebAuthenticationSession` is available. In general, system browsers share cookies and other website data with the Safari browser application.
+
+By default, MSAL will dynamically detect iOS version and select the recommended system browser available on that version. On iOS 12+ it will be `ASWebAuthenticationSession`.
+
+### Default configuration for iOS
+
+| Version |        Web browser         |
+| :-----: | :------------------------: |
+| iOS 12+ | ASWebAuthenticationSession |
+| iOS 11  |  SFAuthenticationSession   |
+| iOS 10  |   SFSafariViewController   |
+
+### Default configuration for macOS
+
+|    Version     |        Web browser         |
+| :------------: | :------------------------: |
+|  macOS 10.15+  | ASWebAuthenticationSession |
+| other versions |         WKWebView          |
+
+Developers can also select a different system browser for MSAL apps:
+
+- `SFAuthenticationSession` is the iOS 11 version of `ASWebAuthenticationSession`.
+- `SFSafariViewController` is more general purpose and provides an interface for browsing the web and can be used for login purposes as well. In iOS 9 and 10, cookies and other website data are shared with Safari--but not in iOS 11 and later.
+
+## In-app browser
+
+[WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) is an in-app browser that displays web content. It doesn't share cookies or web site data with other **WKWebView** instances, or with the Safari browser. WKWebView is a cross-platform browser that is available for both iOS and macOS.
+
+## Cookie sharing and SSO implications
+
+The browser you use impacts the SSO experience because of how they share cookies. The following tables summarize the SSO experiences per browser.
+
+|                                                        Technology                                                         | Browser Type | iOS availability | macOS availability | Shares cookies and other data |  MSAL availability   |                 SSO |
+| :-----------------------------------------------------------------------------------------------------------------------: | :----------: | :--------------: | :----------------: | :---------------------------: | :------------------: | ------------------: |
+| [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) |    System    |   iOS12 and up   | macOS 10.15 and up |              Yes              | iOS and macOS 10.15+ | w/ Safari instances |
+|        [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession)        |    System    |   iOS11 and up   |        N/A         |              Yes              |       iOS only       | w/ Safari instances |
+|         [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller)         |    System    |   iOS11 and up   |        N/A         |              No               |       iOS only       |              No\*\* |
+|                                                **SFSafariViewController**                                                 |    System    |      iOS10       |        N/A         |              Yes              |       iOS only       | w/ Safari instances |
+|                                                       **WKWebView**                                                       |    In-app    |   iOS8 and up    | macOS 10.10 and up |              No               |    iOS and macOS     |              No\*\* |
+
+\*\* For SSO to work, tokens need to be shared between apps. This requires a token cache, or broker application, such as Microsoft Authenticator for iOS.
+
+## Change the default browser for the request
+
+You can use an in-app browser, or a specific system browser depending on your UX requirements, by changing the following property in `MSALWebviewParameters`:
+
+```objc
+@property (nonatomic) MSALWebviewType webviewType;
+```
+
+## Change per interactive request
+
+Each request can be configured to override the default browser by changing the `MSALInteractiveTokenParameters.webviewParameters.webviewType` property before passing it to the `acquireTokenWithParameters:completionBlock:` API.
+
+Additionally, MSAL supports passing in a custom `WKWebView` by setting the `MSALInteractiveTokenParameters.webviewParameters.customWebView` property.
+
+For example:
+
+Objective-C
+
+```objc
+UIViewController *myParentController = ...;
+WKWebView *myCustomWebView = ...;
+MSALWebviewParameters *webViewParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:myParentController];
+webViewParameters.webviewType = MSALWebviewTypeWKWebView;
+webViewParameters.customWebview = myCustomWebView;
+MSALInteractiveTokenParameters *interactiveParameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"myscope"] webviewParameters:webViewParameters];
+
+[app acquireTokenWithParameters:interactiveParameters completionBlock:completionBlock];
+```
+
+Swift
+
+```swift
+let myParentController: UIViewController = ...
+let myCustomWebView: WKWebView = ...
+let webViewParameters = MSALWebviewParameters(authPresentationViewController: myParentController)
+webViewParameters.webviewType = MSALWebviewType.wkWebView
+webViewParameters.customWebview = myCustomWebView
+let interactiveParameters = MSALInteractiveTokenParameters(scopes: ["myscope"], webviewParameters: webViewParameters)
+
+app.acquireToken(with: interactiveParameters, completionBlock: completionBlock)
+```
+
+If you use a custom webview, notifications are used to indicate the status of the web content being displayed, such as:
+
+```objc
+/*! Fired at the start of a resource load in the webview. The URL of the load, if available, will be in the @"url" key in the userInfo dictionary */
+extern NSString *MSALWebAuthDidStartLoadNotification;
+
+/*! Fired when a resource finishes loading in the webview. */
+extern NSString *MSALWebAuthDidFinishLoadNotification;
+
+/*! Fired when web authentication fails due to reasons originating from the network. Look at the @"error" key in the userInfo dictionary for more details.*/
+extern NSString *MSALWebAuthDidFailNotification;
+
+/*! Fired when authentication finishes */
+extern NSString *MSALWebAuthDidCompleteNotification;
+
+/*! Fired before ADAL invokes the broker app */
+extern NSString *MSALWebAuthWillSwitchToBrokerApp;
+```
+
+### Options
+
+All MSAL supported web browser types are declared in the [MSALWebviewType enum](https://github.com/AzureAD/microsoft-authentication-library-for-objc/blob/master/MSAL/src/public/MSALDefinitions.h#L47)
+
+```objc
+typedef NS_ENUM(NSInteger, MSALWebviewType)
+{
+    /**
+     For iOS 11 and up, uses AuthenticationSession (ASWebAuthenticationSession or SFAuthenticationSession).
+     For older versions, with AuthenticationSession not being available, uses SafariViewController.
+     For macOS 10.15 and above uses ASWebAuthenticationSession
+     For older macOS versions uses WKWebView
+     */
+    MSALWebviewTypeDefault,
+
+    /** Use ASWebAuthenticationSession where available.
+     On older iOS versions uses SFAuthenticationSession
+     Doesn't allow any other webview type, so if either of these are not present, fails the request*/
+    MSALWebviewTypeAuthenticationSession,
+
+#if TARGET_OS_IPHONE
+
+    /** Use SFSafariViewController for all versions. */
+    MSALWebviewTypeSafariViewController,
+
+#endif
+    /** Use WKWebView */
+    MSALWebviewTypeWKWebView,
+};
+```
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/howto-v2-keychain-objc.md
+++ b/msal-objc-articles/howto-v2-keychain-objc.md
@@ -1,0 +1,108 @@
+---
+title: Configure keychain 
+description: Learn how to configure keychain so that your app can cache tokens in the keychain.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.workload: identity
+ms.topic: how-to
+ms.date: 12/19/2022
+ms.author: owenrichards
+ms.reviewer: oldalton
+ms.custom: aaddev, has-adal-ref, engagement-fy23
+---
+
+# Configure keychain
+
+When the [Microsoft Authentication Library for iOS and macOS](msal-overview.md) (MSAL) signs in a user, or refreshes a token, it tries to cache tokens in the keychain. Caching tokens in the keychain allows MSAL to provide silent single sign-on (SSO) between multiple apps that are distributed by the same Apple developer. SSO is achieved via the keychain access groups functionality. For more information, see Apple's [Keychain Items documentation](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc).
+
+This article covers how to configure app entitlements so that MSAL can write cached tokens to iOS and macOS keychain.
+
+## Default keychain access group
+
+### iOS
+
+MSAL on iOS uses the `com.microsoft.adalcache` access group by default. This ensures the best SSO experience between multiple apps from the same publisher.
+
+On iOS, add the `com.microsoft.adalcache` keychain group to your app's entitlement in XCode under **Project settings** > **Capabilities** > **Keychain sharing**.
+
+### macOS
+
+MSAL on macOS uses `com.microsoft.identity.universalstorage` access group by default.
+
+Due to macOS keychain limitations, MSAL's `access group` doesn't directly translate to the keychain access group attribute (see [kSecAttrAccessGroup](https://developer.apple.com/documentation/security/ksecattraccessgroup?language=objc)) on macOS 10.14 and earlier. However, it behaves similarly from an SSO perspective by ensuring that multiple applications distributed by the same Apple developer can have silent SSO.
+
+On macOS 10.15 onwards (macOS Catalina), MSAL uses keychain access group attribute to achieve silent SSO, similarly to iOS.
+
+## Custom keychain access group
+
+If you'd like to use a different keychain access group, you can pass your custom group when creating `MSALPublicClientApplicationConfig` before creating `MSALPublicClientApplication`, like this:
+
+# [Objective-C](#tab/objc)
+
+```objc
+MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"your-client-id"
+                                                                                            redirectUri:@"your-redirect-uri"
+                                                                                              authority:nil];
+    
+config.cacheConfig.keychainSharingGroup = @"custom-group";
+    
+MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:nil];
+    
+// Now call `acquiretoken`. 
+// Tokens will be saved into the "custom-group" access group
+// and only shared with other applications declaring the same access group
+```
+
+# [Swift](#tab/swift)
+
+```swift
+let config = MSALPublicClientApplicationConfig(clientId: "your-client-id",
+                                            redirectUri: "your-redirect-uri",
+                                              authority: nil)
+config.cacheConfig.keychainSharingGroup = "custom-group"
+        
+do {
+  let application = try MSALPublicClientApplication(configuration: config)
+  // continue on with application          
+} catch let error as NSError {
+  // handle error here
+}       
+```
+
+---
+
+## Disable keychain sharing
+
+If you don't want to share SSO state between multiple apps, or use any keychain access group, disable keychain sharing by passing the application bundle ID as your keychainGroup:
+
+# [Objective-C](#tab/objc)
+
+```objc
+config.cacheConfig.keychainSharingGroup = [[NSBundle mainBundle] bundleIdentifier];
+```
+
+# [Swift](#tab/swift)
+
+```swift
+if let bundleIdentifier = Bundle.main.bundleIdentifier {
+    config.cacheConfig.keychainSharingGroup = bundleIdentifier
+}
+```
+
+---
+
+## Handle -34018 error (failed to set item into keychain)
+
+Error -34018 normally means that the keychain hasn't been configured correctly. Ensure the keychain access group that has been configured in MSAL matches the one configured in entitlements.
+
+## Ensure your application is properly signed
+
+On macOS, applications can execute without being signed by the developer. While most of MSAL's functionality will continue to work, SSO through keychain access requires application to be signed. If you're experiencing multiple keychain prompts, make sure your application's signature is valid.
+
+## Next steps
+
+Learn more about keychain access groups in Apple's [Sharing Access to Keychain Items Among a Collection of Apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc) article.

--- a/msal-objc-articles/iOS-13-and-macOS-10.15-support-in-MSAL.md
+++ b/msal-objc-articles/iOS-13-and-macOS-10.15-support-in-MSAL.md
@@ -1,0 +1,45 @@
+If your app requires conditional access or certificate authentication support, you must set up your MSAL to be able to talk to the Azure Authenticator app.
+
+MSAL is then responsible for handling requests and responses between your application and the Azure Authenticator app.
+
+However, on iOS 13, Apple made a breaking API change, and removed application's ability to read source application when receiving a response from an external application through custom URL schemes. See notes from Apple [here](https://developer.apple.com/documentation/uikit/uiapplicationopenurloptionssourceapplicationkey?language=objc). 
+
+> If the request originated from another app belonging to your team, UIKit sets the value of this key to the ID of that app. If the team identifier of the originating app is different than the team identifier of the current app, the value of the key is nil.
+
+This is a breaking change for MSAL, because it relied on the `UIApplicationOpenURLOptionsSourceApplicationKey` to verify communication between MSAL and the Azure Authenticator app. 
+
+Additionally, on iOS 13 developer is required to provide a presentation controller when using ASWebAuthenticationSession.
+
+In order to mitigate these changes, we released a new MSAL version with iOS 13 support:
+- [MSAL 0.7.0](https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/tag/0.7.0)
+
+### Your app is impacted if:
+1. Your app is leveraging iOS broker, AND you're building with Xcode 11, OR
+2. You're using ASWebAuthenticationSession, AND you're building with Xcode 11.
+
+In those cases you need to use latest MSAL releases to be able to complete authentication successfully.
+
+### Your app is NOT impacted if:
+1. Your app is not using iOS broker, OR
+2. Your app is being built with Xcode 11, OR
+3. Your app is distributed by Microsoft (signed by Microsoft developer distribution profile), OR
+4. You're not using ASWebAuthenticationSession.
+
+### Additional considerations:
+
+1. When using latest MSAL SDKs, you need to ensure that you have the latest Authenticator app installed. Authenticator app with a version 6.3.19 or later is supported. 
+
+2. When updating to this release, make sure you update your LSApplicationQueriesSchemes in the Info.plist. 
+New value should be:
+
+```
+<key>LSApplicationQueriesSchemes</key>
+<array>
+     <string>msauthv2</string>
+     <string>msauthv3</string>
+</array>
+```
+
+This is necessary to detect the presence of the latest Authenticator app on device that supports iOS 13. 
+
+Please open [a Github issue](https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues) if you have additional questions or seeing any issues. 

--- a/msal-objc-articles/index.md
+++ b/msal-objc-articles/index.md
@@ -1,1 +1,7 @@
-# Welcome to msal-objc-articles!
+# Microsoft Authentication Library for iOS and macOS
+
+The Objective-C Microsoft Authentication Library (MSAL) is an Auth SDK that can be used to seamlessly integrate authentication into your app and give access to the entire Microsoft ecosystem.
+
+This platform allows you to easily target several identities including Azure AD (Work and School accounts), Microsoft account (Outlook.com, hotmail.com, and several others), or Azure AD B2C (Social and Local accounts). Your app will then have access to the entire set of Microsoft cloud APIs including the Microsoft Graph, Office 365, Azure, and any API you want to protect.
+
+The wiki is intended to document common patterns, error handling & debugging best practices, extra library functionality (e.g. logging, telemetry), and any active bugs or common issues with known mitigations. If you're looking for more help getting started with Azure AD, Microsoft Accounts, or Azure AD B2C, check out the full Microsoft identity platform docs. If you're looking for more info about the Microsoft Graph API, check out the Microsoft Graph docs.

--- a/msal-objc-articles/logging-ios.md
+++ b/msal-objc-articles/logging-ios.md
@@ -1,0 +1,181 @@
+---
+title: Logging errors and exceptions in MSAL for iOS/macOS
+description: Learn how to log errors and exceptions in MSAL for iOS/macOS
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 01/25/2021
+ms.author: henrymbugua
+ms.reviewer: saeeda, jmprieur
+ms.custom: aaddev
+---
+
+# Logging in MSAL for iOS/macOS
+
+[!INCLUDE [MSAL logging introduction](./includes/error-handling-and-tips/error-logging-introduction.md)]
+
+## [Objective-C](#tab/objc)
+
+## MSAL for iOS and macOS logging-ObjC
+
+Set a callback to capture MSAL logging and incorporate it in your own application's logging. The signature for the callback looks like this:
+
+```objc
+/*!
+    The LogCallback block for the MSAL logger
+
+    @param  level           The level of the log message
+    @param  message         The message being logged
+    @param  containsPII     If the message might contain Personally Identifiable Information (PII)
+                            this will be true. Log messages possibly containing PII will not be
+                            sent to the callback unless PIllLoggingEnabled is set to YES on the
+                            logger.
+
+ */
+typedef void (^MSALLogCallback)(MSALLogLevel level, NSString *message, BOOL containsPII);
+```
+
+For example:
+
+```objc
+[MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString *message, BOOL containsPII)
+    {
+        if (!containsPII)
+        {
+#if DEBUG
+            // IMPORTANT: MSAL logs may contain sensitive information. Never output MSAL logs with NSLog, or print, directly unless you're running your application in debug mode. If you're writing MSAL logs to file, you must store the file securely.
+            NSLog(@"MSAL log: %@", message);
+#endif
+        }
+    }];
+```
+
+### Personal data
+
+By default, MSAL doesn't capture or log any personal data. The library allows app developers to turn this on through a property in the MSALLogger class. By turning on `pii.Enabled`, the app takes responsibility for safely handling highly sensitive data and following regulatory requirements.
+
+```objc
+// By default, the `MSALLogger` doesn't capture any PII
+
+// PII will be logged
+MSALGlobalConfig.loggerConfig.piiEnabled = YES;
+
+// PII will NOT be logged
+MSALGlobalConfig.loggerConfig.piiEnabled = NO;
+```
+
+### Logging levels
+
+To set the logging level when you log using MSAL for iOS and macOS, use one of the following values:
+
+|Level  |Description |
+|---------|---------|
+| `MSALLogLevelNothing`| Disable all logging |
+| `MSALLogLevelError` | Default level, prints out information only when errors occur |
+| `MSALLogLevelWarning` | Warnings |
+| `MSALLogLevelInfo` |  Library entry points, with parameters and various keychain operations |
+|`MSALLogLevelVerbose`     |  API tracing |
+
+For example:
+
+```objc
+MSALGlobalConfig.loggerConfig.logLevel = MSALLogLevelVerbose;
+```
+
+ ### Log message format
+
+The message portion of MSAL log messages is in the format of `TID = <thread_id> MSAL <sdk_ver> <OS> <OS_ver> [timestamp - correlation_id] message`
+
+For example:
+
+`TID = 551563 MSAL 0.2.0 iOS Sim 12.0 [2018-09-24 00:36:38 - 36764181-EF53-4E4E-B3E5-16FE362CFC44] acquireToken returning with error: (MSALErrorDomain, -42400) User cancelled the authorization session.`
+
+Providing correlation IDs and timestamps are helpful for tracking down issues. Timestamp and correlation ID information is available in the log message. The only reliable place to retrieve them is from MSAL logging messages.
+
+## [Swift](#tab/swift)
+
+## MSAL for iOS and macOS logging-Swift
+
+Set a callback to capture MSAL logging and incorporate it in your own application's logging. The signature (represented in Objective-C) for the callback looks like this:
+
+```objc
+/*!
+    The LogCallback block for the MSAL logger
+
+    @param  level           The level of the log message
+    @param  message         The message being logged
+    @param  containsPII     If the message might contain Personally Identifiable Information (PII)
+                            this will be true. Log messages possibly containing PII will not be
+                            sent to the callback unless PIllLoggingEnabled is set to YES on the
+                            logger.
+
+ */
+typedef void (^MSALLogCallback)(MSALLogLevel level, NSString *message, BOOL containsPII);
+```
+
+For example:
+
+```swift
+MSALGlobalConfig.loggerConfig.setLogCallback { (level, message, containsPII) in
+    if let message = message, !containsPII
+    {
+#if DEBUG
+    // IMPORTANT: MSAL logs may contain sensitive information. Never output MSAL logs with NSLog, or print, directly unless you're running your application in debug mode. If you're writing MSAL logs to file, you must store the file securely.
+    print("MSAL log: \(message)")
+#endif
+    }
+}
+```
+
+### Personal data
+
+By default, MSAL doesn't capture or log any personal data. The library allows app developers to turn this on through a property in the MSALLogger class. By turning on `pii.Enabled`, the app takes responsibility for safely handling highly sensitive data and following regulatory requirements.
+
+```swift
+// By default, the `MSALLogger` doesn't capture any PII
+
+// PII will be logged
+MSALGlobalConfig.loggerConfig.piiEnabled = true
+
+// PII will NOT be logged
+MSALGlobalConfig.loggerConfig.piiEnabled = false
+```
+
+### Logging levels
+
+To set the logging level when you log using MSAL for iOS and macOS, use one of the following values:
+
+|Level  |Description |
+|---------|---------|
+| `MSALLogLevelNothing`| Disable all logging |
+| `MSALLogLevelError` | Default level, prints out information only when errors occur |
+| `MSALLogLevelWarning` | Warnings |
+| `MSALLogLevelInfo` |  Library entry points, with parameters and various keychain operations |
+|`MSALLogLevelVerbose`     |  API tracing |
+
+For example:
+
+```swift
+MSALGlobalConfig.loggerConfig.logLevel = .verbose
+```
+
+### Log message format
+
+The message portion of MSAL log messages is in the format of `TID = <thread_id> MSAL <sdk_ver> <OS> <OS_ver> [timestamp - correlation_id] message`
+
+For example:
+
+`TID = 551563 MSAL 0.2.0 iOS Sim 12.0 [2018-09-24 00:36:38 - 36764181-EF53-4E4E-B3E5-16FE362CFC44] acquireToken returning with error: (MSALErrorDomain, -42400) User cancelled the authorization session.`
+
+Providing correlation IDs and timestamps are helpful for tracking down issues. Timestamp and correlation ID information is available in the log message. The only reliable place to retrieve them is from MSAL logging messages.
+
+---
+
+## Next steps
+
+For more code samples, refer to [Microsoft identity platform code samples](sample-v2-code.md).

--- a/msal-objc-articles/migrate-objc-adal-msal.md
+++ b/msal-objc-articles/migrate-objc-adal-msal.md
@@ -1,0 +1,464 @@
+---
+title: ADAL to MSAL migration guide (MSAL iOS/macOS)
+description: Learn the differences between MSAL for iOS/macOS and the Azure AD Authentication Library for Objective-C (ADAL.ObjC) and how to migrate to MSAL for iOS/macOS.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 08/28/2019
+ms.author: owenrichards
+ms.reviewer: oldalton
+ms.custom: aaddev, has-adal-ref
+#Customer intent: As an application developer, I want to learn about the differences between the Objective-C ADAL and MSAL for iOS and macOS libraries so I can migrate my applications to MSAL for iOS and macOS.
+---
+
+# Migrate applications to MSAL for iOS and macOS
+
+The Azure Active Directory Authentication Library ([ADAL Objective-C](https://github.com/AzureAD/azure-activedirectory-library-for-objc)) was created to work with  Microsoft Entra accounts via the v1.0 endpoint.
+
+The Microsoft Authentication Library for iOS and macOS (MSAL) is built to work with all Microsoft identities such as Microsoft Entra accounts, personal Microsoft accounts, and Azure AD B2C accounts via the Microsoft identity platform (formally the Azure AD v2.0 endpoint).
+
+The Microsoft identity platform has a few key differences with Azure AD v1.0. This article highlights these differences and provides guidance to migrate an app from ADAL to MSAL.
+
+## ADAL and MSAL app capability differences
+
+### Who can sign in
+
+* ADAL only supports work and school accounts--also known as Microsoft Entra accounts.
+* MSAL supports personal Microsoft accounts (MSA accounts) such as Hotmail.com, Outlook.com, and Live.com.
+* MSAL supports work and school accounts, and Azure AD B2C accounts.
+
+### Standards compliance
+
+* The Microsoft identity platform follows OAuth 2.0 and OpenId Connect standards.
+
+### Incremental and dynamic consent
+
+* The Microsoft identity platform allows you to request permissions dynamically. Apps can ask for permissions only as needed and request more as the app needs them. For more information, see [permissions and consent](./permissions-consent-overview.md#consent).
+
+## ADAL and MSAL library differences
+
+The MSAL public API reflects a few key differences between Azure AD v1.0 and the Microsoft identity platform.
+
+### MSALPublicClientApplication instead of ADAuthenticationContext
+
+`ADAuthenticationContext` is the first object an ADAL app creates. It represents an instantiation of ADAL. Apps create a new instance of `ADAuthenticationContext` for each Microsoft Entra cloud and tenant (authority) combination. The same `ADAuthenticationContext` can be used to get tokens for multiple public client applications.
+
+In MSAL, the main interaction is through an `MSALPublicClientApplication` object, which is modeled after [OAuth 2.0 Public Client](https://tools.ietf.org/html/rfc6749#section-2.1). One instance of `MSALPublicClientApplication` can be used to interact with multiple Microsoft Entra clouds, and tenants, without needing to create a new instance for each authority. For most apps, one `MSALPublicClientApplication` instance is sufficient.
+
+### Scopes instead of resources
+
+In ADAL, an app had to provide a *resource* identifier like `https://graph.microsoft.com` to acquire tokens from the Azure AD v1.0 endpoint. A resource can define a number of scopes, or oAuth2Permissions in the app manifest, that it understands. This allowed client apps to request tokens from that resource for a certain set of scopes pre-defined during app registration.
+
+In MSAL, instead of a single resource identifier, apps provide a set of scopes per request. A scope is a resource identifier followed by a permission name in the form resource/permission. For example, `https://graph.microsoft.com/user.read`
+
+There are two ways to provide scopes in MSAL:
+
+* Provide a list of all the permissions your apps needs. For example: 
+
+    `@[@"https://graph.microsoft.com/directory.read", @"https://graph.microsoft.com/directory.write"]`
+
+    In this case, the app requests the `directory.read` and `directory.write` permissions. The user will be asked to consent for those permissions if they haven't consented to them before for this app. The application might also receive additional permissions that the user has already consented to for the application. The user will only be prompted to consent for new permissions, or permissions that haven't been granted.
+
+* The `/.default` scope.
+
+This is the built-in scope for every application. It refers to the static list of permissions configured when the application was registered. Its behavior is similar to that of `resource`. This can be useful when migrating to ensure that a similar set of scopes and user experience is maintained.
+
+To use the `/.default` scope, append `/.default` to the resource identifier. For example: `https://graph.microsoft.com/.default`. If your resource ends with a slash (`/`), you should still append `/.default`, including the leading forward slash, resulting in a scope that has a double forward slash (`//`) in it.
+
+You can read more information about using the "/.default" scope [here](./permissions-consent-overview.md).
+
+### Supporting different WebView types & browsers
+
+ADAL only supports UIWebView/WKWebView for iOS, and WebView for macOS. MSAL for iOS supports more options for displaying web content when requesting an authorization code, and no longer supports `UIWebView`; which can improve the user experience and security.
+
+By default, MSAL on iOS uses [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession?language=objc), which is the web component Apple recommends for authentication on iOS 12+ devices. It provides single sign-on (SSO) benefits through cookie sharing between apps and the Safari browser.
+
+You can choose to use a different web component depending on app requirements and the end-user experience you want. See [supported web view types](customize-webviews.md) for more options.
+
+When migrating from ADAL to MSAL, `WKWebView` provides the user experience most similar to ADAL on iOS and macOS. We encourage you to migrate to `ASWebAuthenticationSession` on iOS, if possible. For macOS, we encourage you to use `WKWebView`.
+
+### Account management API differences
+
+When you call the ADAL methods `acquireToken()` or `acquireTokenSilent()`, you receive an `ADUserInformation` object containing a list of claims from the `id_token` that represents the account being authenticated. Additionally, `ADUserInformation` returns a `userId` based on the `upn` claim. After initial interactive token acquisition, ADAL expects developer to provide `userId` in all silent calls.
+
+ADAL doesn't provide an API to retrieve known user identities. It relies on the app to save and manage those accounts.
+
+MSAL provides a set of APIs to list all accounts known to MSAL without having to acquire a token.
+
+Like ADAL, MSAL returns account information that holds a list of claims from the `id_token`. It's part of the `MSALAccount` object inside the `MSALResult` object.
+
+MSAL provides a set of APIs to remove accounts, making the removed accounts inaccessible to the app. After the account is removed, later token acquisition calls will prompt the user to do interactive token acquisition. Account removal only applies to the client application that started it, and doesn't remove the account from the other apps running on the device or from the system browser. This ensures that the user continues to have a SSO experience on the device even after signing out of an individual app.
+
+Additionally, MSAL also returns an account identifier that can be used to request a token silently later. However, the account identifier (accessible through `identifier` property in the `MSALAccount` object) isn't displayable and you can't assume what format it is in nor should you try to interpret or parse it.
+
+### Migrating the account cache
+
+When migrating from ADAL, apps normally store ADAL's `userId`, which doesn't have the `identifier` required by MSAL. As a one-time migration step, an app can query an MSAL account using ADAL's userId with the following API:
+
+`- (nullable MSALAccount *)accountForUsername:(nonnull NSString *)username error:(NSError * _Nullable __autoreleasing * _Nullable)error;`
+
+This API reads both MSAL's and ADAL's cache to find the account by ADAL userId (UPN).
+
+If the account is found, the developer should use the account to do silent token acquisition. The first silent token acquisition will effectively upgrade the account, and the developer will get a MSAL compatible account identifier in the MSAL result (`identifier`). After that, only `identifier` should be used for  account lookups by using the following API:
+
+`- (nullable MSALAccount *)accountForIdentifier:(nonnull NSString *)identifier error:(NSError * _Nullable __autoreleasing * _Nullable)error;`
+
+Although it's possible to continue using ADAL's `userId` for all operations in MSAL, since `userId` is based on UPN, it's subject to multiple limitations that result in a bad user experience. For example, if the UPN changes, the user has to sign in again. We recommend all apps use the non-displayable account `identifier` for all operations.
+
+Read more about [cache state migration](sso-between-adal-msal-apps-macos-ios.md).
+
+### Token acquisition changes
+
+MSAL introduces some token acquisition call changes:
+
+* Like ADAL, `acquireTokenSilent` always results in a silent request.
+* Unlike ADAL, `acquireToken` always results in user actionable UI either through the web view or the Microsoft Authenticator app. Depending on the SSO state inside webview/Microsoft Authenticator, the user may be prompted to enter their credentials.
+* In ADAL, `acquireToken` with `AD_PROMPT_AUTO` first tries silent token acquisition, and only shows UI if the silent request fails. In MSAL, this logic can be achieved by first calling `acquireTokenSilent` and only calling `acquireToken` if silent acquisition fails. This allows developers to customize user experience before starting interactive token acquisition.
+
+### Error handling differences
+
+MSAL provides more clarity between errors that can be handled by your app and those that require intervention by the user. There are a limited number of errors developer must handle:
+
+* `MSALErrorInteractionRequired`: The user must do an interactive request. This can be caused for various reasons such as an expired authentication session, Conditional Access policy has changed, a refresh token expired or was revoked, there are no valid tokens in the cache, and so on.
+* `MSALErrorServerDeclinedScopes`: The request wasn't fully completed and some scopes weren't granted access. This can be caused by a user declining consent to one or more scopes.
+
+Handling all other errors in the [`MSALError` list](https://github.com/AzureAD/microsoft-authentication-library-for-objc/blob/master/MSAL/src/public/MSALError.h#L128) is optional. You could use the information in those errors to improve the user experience.
+
+See [Handling exceptions and errors using MSAL](msal-error-handling-ios.md) for more about MSAL error handling.
+
+### Broker support
+
+MSAL, starting with version 0.3.0, provides support for brokered authentication using the Microsoft Authenticator app. Microsoft Authenticator also enables support for Conditional Access scenarios. Examples of Conditional Access scenarios include device compliance policies that require the user to enroll the device through Intune or register with Microsoft Entra ID to get a token. And Mobile Application Management (MAM) Conditional Access policies, which require proof of compliance before your app can get a token.
+
+To enable broker for your application:
+
+1. Register a broker compatible redirect URI format for the application. The broker compatible redirect URI format is `msauth.<app.bundle.id>://auth`. Replace `<app.bundle.id>` with your application's bundle ID. If you're migrating from ADAL and your application was already broker capable, there's nothing extra you need to do. Your previous redirect URI is fully compatible with MSAL, so you can skip to step 3.
+
+2. Add your application's redirect URI scheme to your info.plist file. For the default MSAL redirect URI, the format is `msauth.<app.bundle.id>`. For example:
+
+    ```xml
+    <key>CFBundleURLSchemes</key>
+    <array>
+        <string>msauth.<app.bundle.id></string>
+    </array>
+    ```
+
+3. Add following schemes to your app's Info.plist under LSApplicationQueriesSchemes:
+
+    ```xml
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+         <string>msauthv2</string>
+         <string>msauthv3</string>
+    </array>
+    ```
+
+4. Add the following to your AppDelegate.m file to handle callbacks:
+Objective-C:
+    
+    ```objc
+    - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options`
+    {
+        return [MSALPublicClientApplication handleMSALResponse:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+    }
+    ```
+    
+    Swift:
+    
+    ```swift
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        return MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
+    }
+    ```
+
+### Business to business (B2B)
+
+In ADAL, you create separate instances of `ADAuthenticationContext` for each tenant that the app requests tokens for. This is no longer a requirement in MSAL. In MSAL, you can create a single instance of `MSALPublicClientApplication` and use it for any Microsoft Entra cloud and organization by specifying a different authority for acquireToken and acquireTokenSilent calls.
+
+## SSO in partnership with other SDKs
+
+MSAL for iOS can achieve SSO via a unified cache with the following SDKs:
+
+- ADAL Objective-C 2.7.x+
+- MSAL.NET for Xamarin 2.4.x+
+- ADAL.NET for Xamarin 4.4.x+
+
+SSO is achieved via iOS keychain sharing and is only available between apps published from the same Apple Developer account.
+
+SSO through iOS keychain sharing is the only silent SSO type.
+
+On macOS, MSAL can achieve SSO with other MSAL for iOS and macOS based applications and ADAL Objective-C-based applications.
+
+MSAL on iOS also supports two other types of SSO:
+
+* SSO through the web browser. MSAL for iOS supports `ASWebAuthenticationSession`, which provides SSO through cookies shared between other apps on the device and specifically the Safari browser.
+* SSO through an Authentication broker. On an iOS device, Microsoft Authenticator acts as the Authentication broker. It can follow Conditional Access policies such as requiring a compliant device, and provides SSO for registered devices. MSAL SDKs starting with version 0.3.0 support a broker by default.
+
+## Intune MAM SDK
+
+The [Intune MAM SDK](/intune/app-sdk-get-started) supports MSAL for iOS starting with version [11.1.2](https://github.com/msintuneappsdk/ms-intune-app-sdk-ios/releases/tag/11.1.2)
+
+## MSAL and ADAL in the same app
+
+ADAL version 2.7.0, and above, can't coexist with MSAL in the same application. The main reason is because of the shared submodule common code. Because Objective-C doesn't support namespaces, if you add both ADAL and MSAL frameworks to your application, there will be two instances of the same class. There's no guarantee for which one gets picked at runtime. If both SDKs are using same version of the conflicting class, your app may still work. However, if it's a different version, your app might experience unexpected crashes that are difficult to diagnose.
+
+Running ADAL and MSAL in the same production application isn't supported. However, if you're just testing and migrating your users from ADAL Objective-C to MSAL for iOS and macOS, you can continue using [ADAL Objective-C 2.6.10](https://github.com/AzureAD/azure-activedirectory-library-for-objc/releases/tag/2.6.10). It's the only version that works with MSAL in the same application. There will be no new feature updates for this ADAL version, so it should be only used for migration and testing purposes. Your app shouldn't rely on ADAL and MSAL coexistence long term.
+
+ADAL and MSAL coexistence in the same application isn't supported.
+ADAL and MSAL coexistence between multiple applications is fully supported.
+
+## Practical migration steps
+
+### App registration migration
+
+You don't need to change your existing Microsoft Entra application to switch to MSAL and enable Microsoft Entra accounts. However, if your ADAL-based application doesn't support brokered authentication, you'll need to register a new redirect URI for the application before you can switch to MSAL.
+
+The redirect URI should be in this format: `msauth.<app.bundle.id>://auth`. Replace `<app.bundle.id>` with your application's bundle ID. Specify the redirect URI in the [Microsoft Entra admin center](https://entra.microsoft.com/?feature.broker=true#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
+
+For iOS only, to support cert-based authentication, an additional redirect URI needs to be registered in your application and the Microsoft Entra admin center in the following format: `msauth://code/<broker-redirect-uri-in-url-encoded-form>`. For example, `msauth://code/msauth.com.microsoft.mybundleId%3A%2F%2Fauth`
+
+We recommend all apps register both redirect URIs.
+
+If you wish to add support for incremental consent, select the APIs and permissions your app is configured to request access to in your app registration under the **API permissions** tab.
+
+If you're migrating from ADAL and want to support both Microsoft Entra ID and MSA accounts, your existing application registration needs to be updated to support both. We don't recommend you update your existing production app to support both Microsoft Entra ID and MSA right away. Instead, create another client ID that supports both Microsoft Entra ID and MSA for testing, and after you've verified that all scenarios work, update the existing app.
+
+### Add MSAL to your app
+
+You can add MSAL SDK to your app using your preferred package management tool. See [detailed instructions here](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki/Installation).
+
+### Update your app's Info.plist file
+
+For iOS only, add your application's redirect URI scheme to your info.plist file. For ADAL broker compatible apps, it should be there already. The default MSAL redirect URI scheme will be in the format: `msauth.<app.bundle.id>`.  
+
+```xml
+<key>CFBundleURLSchemes</key>
+<array>
+    <string>msauth.<app.bundle.id></string>
+</array>
+```
+
+Add following schemes to your app's Info.plist under `LSApplicationQueriesSchemes`.
+
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+     <string>msauthv2</string>
+     <string>msauthv3</string>
+</array>
+```
+
+### Update your AppDelegate code
+
+For iOS only, add the following to your AppDelegate.m file:
+
+Objective-C:
+
+```objc
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options`
+{
+    return [MSALPublicClientApplication handleMSALResponse:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+}
+```
+
+Swift:
+
+```swift
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
+}
+```
+
+**If you are using Xcode 11**, you should place MSAL callback into the `SceneDelegate` file instead.
+If you support both UISceneDelegate and UIApplicationDelegate for compatibility with older iOS, MSAL callback would need to be placed into both files.
+
+Objective-C:
+
+```objc
+ - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+ {
+     UIOpenURLContext *context = URLContexts.anyObject;
+     NSURL *url = context.URL;
+     NSString *sourceApplication = context.options.sourceApplication;
+     
+     [MSALPublicClientApplication handleMSALResponse:url sourceApplication:sourceApplication];
+ }
+```
+
+Swift:
+
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        
+        guard let urlContext = URLContexts.first else {
+            return
+        }
+        
+        let url = urlContext.url
+        let sourceApp = urlContext.options.sourceApplication
+        
+        MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: sourceApp)
+    }
+```
+
+This allows MSAL to handle responses from the broker and web component.
+This wasn't necessary in ADAL since it "swizzled" app delegate methods automatically. Adding it manually is less error prone and gives the application more control.
+
+### Enable token caching
+
+By default, MSAL caches your app's tokens in the iOS or macOS keychain. 
+
+To enable token caching:
+1. Ensure your application is properly signed
+2. Go to your Xcode Project Settings > **Capabilities tab** > **Enable Keychain Sharing**
+3. Click **+** and enter a following **Keychain Groups** entry:
+3.a For iOS, enter `com.microsoft.adalcache`
+3.b For macOS enter `com.microsoft.identity.universalstorage`
+
+### Create MSALPublicClientApplication and switch to its acquireToken and acquireTokeSilent calls
+
+You can create `MSALPublicClientApplication` using following code:
+
+Objective-C:
+
+```objc
+NSError *error = nil;
+MSALPublicClientApplicationConfig *configuration = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"<your-client-id-here>"];
+    
+MSALPublicClientApplication *application =
+[[MSALPublicClientApplication alloc] initWithConfiguration:configuration
+                                                     error:&error];
+```
+
+Swift:
+
+```swift
+let config = MSALPublicClientApplicationConfig(clientId: "<your-client-id-here>")
+do {
+  let application = try MSALPublicClientApplication(configuration: config)
+  // continue on with application
+            
+} catch let error as NSError {
+  // handle error here
+}
+```
+
+Then call the account management API to see if there are any accounts in the cache:
+
+Objective-C:
+
+```objc
+NSString *accountIdentifier = nil /*previously saved MSAL account identifier */;
+NSError *error = nil;
+MSALAccount *account = [application accountForIdentifier:accountIdentifier error:&error];
+```
+
+Swift:
+
+```swift
+// definitions that need to be initialized
+let application: MSALPublicClientApplication!
+let accountIdentifier: String! /*previously saved MSAL account identifier */
+
+do {
+  let account = try application.account(forIdentifier: accountIdentifier)
+  // continue with account usage
+} catch let error as NSError {
+  // handle error here
+}
+```
+
+
+
+or read all of the accounts:
+
+Objective-C:
+
+```objc
+NSError *error = nil;
+NSArray<MSALAccount *> *accounts = [application allAccounts:&error];
+```
+
+Swift:
+
+```swift
+let application: MSALPublicClientApplication!
+do {
+  let accounts = try application.allAccounts()
+  // continue with account usage
+} catch let error as NSError {
+  // handle error here
+}
+```
+
+
+
+If an account is found, call the MSAL `acquireTokenSilent` API:
+
+Objective-C:
+
+```objc
+MSALSilentTokenParameters *silentParameters = [[MSALSilentTokenParameters alloc] initWithScopes:@[@"<your-resource-here>/.default"] account:account];
+    
+[application acquireTokenSilentWithParameters:silentParameters
+                              completionBlock:^(MSALResult *result, NSError *error)
+{
+    if (result)
+    {
+        NSString *accessToken = result.accessToken;
+        // Use your token
+    }
+    else
+    {
+        // Check the error
+        if ([error.domain isEqual:MSALErrorDomain] && error.code == MSALErrorInteractionRequired)
+        {
+            // Interactive auth will be required
+        }
+            
+        // Other errors may require trying again later, or reporting authentication problems to the user
+    }
+}];
+```
+
+Swift:
+
+```swift
+let application: MSALPublicClientApplication!
+let account: MSALAccount!
+        
+let silentParameters = MSALSilentTokenParameters(scopes: ["<your-resource-here>/.default"], 
+                                                 account: account)
+application.acquireTokenSilent(with: silentParameters) {
+  (result: MSALResult?, error: Error?) in
+  if let accessToken = result?.accessToken {
+     // use accessToken
+  }
+  else {
+    // Check the error
+    guard let error = error else {
+      assert(true, "callback should contain a valid result or error")
+      return
+    }
+    
+    let nsError = error as NSError
+    if (nsError.domain == MSALErrorDomain
+        && nsError.code == MSALError.interactionRequired.rawValue) {
+      // Interactive auth will be required
+    }
+                
+    // Other errors may require trying again later, or reporting authentication problems to the user
+  }
+}
+```
+
+
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/msal-differences-ios-macos.md
+++ b/msal-objc-articles/msal-differences-ios-macos.md
@@ -1,0 +1,56 @@
+---
+title: MSAL for iOS & macOS differences
+description: Describes the Microsoft Authentication Library (MSAL) usage differences between iOS and macOS.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 08/28/2019
+ms.author: henrymbugua
+ms.reviewer: oldalton
+ms.custom: aaddev
+#Customer intent: As an application developer, I want to learn about the Microsoft Authentication Library for macOS and iOS differences so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Microsoft Authentication Library for iOS and macOS differences
+
+This article explains the differences in functionality between the Microsoft Authentication Library (MSAL) for iOS and macOS.
+
+> [!NOTE]
+> On the Mac, MSAL only supports macOS apps.
+
+## General differences
+
+MSAL for macOS is a subset of the functionality available for iOS.
+
+MSAL for macOS doesn't support:
+
+- different browser types such as `ASWebAuthenticationSession`, `SFAuthenticationSession`, `SFSafariViewController`.
+- brokered authentication through Microsoft Authenticator app is not supported for macOS.
+
+Keychain sharing between apps from the same publisher is more limited on macOS 10.14 and earlier. Use [access control lists](https://developer.apple.com/documentation/security/keychain_services/access_control_lists?language=objc) to specify the paths to the apps that should share the keychain. User may see additional keychain prompts.
+
+On macOS 10.15+, MSAL's behavior is the same between iOS and macOS. MSAL uses [keychain access groups](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc) for keychain sharing.
+
+### Conditional Access authentication differences
+
+For Conditional Access scenarios, there will be fewer user prompts when you use MSAL for iOS. This is because iOS uses the broker app (Microsoft Authenticator) which negates the need to prompt the user in some cases.
+
+### Project setup differences
+
+**macOS**
+
+- When you set up your project on macOS, ensure that your application is signed with a valid development or production certificate. MSAL still works in the unsigned mode, but it will behave differently with regards to cache persistence. The app should only be run unsigned for debugging purposes. If you distribute the app unsigned, it will:
+1. On 10.14 and earlier, MSAL will prompt the user for a keychain password every time they restart the app.
+2. On 10.15+, MSAL will prompt user for credentials for every token acquisition.
+
+- macOS apps don't need to implement the AppDelegate call.
+
+**iOS**
+
+- There are additional steps to set up your project to support authentication broker flow. The steps are called out in the tutorial.
+- iOS projects need to register custom schemes in the info.plist. This isn't required on macOS.

--- a/msal-objc-articles/msal-error-handling-ios.md
+++ b/msal-objc-articles/msal-error-handling-ios.md
@@ -1,0 +1,239 @@
+---
+title: Handle errors and exceptions in MSAL for iOS/macOS
+description: Learn how to handle errors and exceptions, Conditional Access claims challenges, and retries in MSAL for iOS/macOS applications.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 11/26/2020
+ms.author: henrymbugua
+ms.reviewer: saeeda, oldalton
+ms.custom: aaddev
+---
+# Handle errors and exceptions in MSAL for iOS/macOS
+
+[!INCLUDE [Active directory error handling introduction](./includes/error-handling-and-tips/error-handling-introduction.md)]
+
+## Error handling in MSAL for iOS/macOS
+
+The complete list of MSAL for iOS and macOS errors is listed in [MSALError enum](https://github.com/AzureAD/microsoft-authentication-library-for-objc/blob/master/MSAL/src/public/MSALError.h#L128).
+
+All MSAL produced errors are returned with `MSALErrorDomain` domain.
+
+For system errors, MSAL returns the original `NSError` from the system API. For example, if token acquisition fails because of a lack of network connectivity, MSAL returns an error with the `NSURLErrorDomain` domain and `NSURLErrorNotConnectedToInternet` code.
+
+We recommend that you handle at least the following two MSAL errors on the client side:
+
+- `MSALErrorInteractionRequired`: The user must do an interactive request. There are many conditions that can lead to this error such as an expired authentication session or the need for additional authentication requirements. Call the MSAL interactive token acquisition API to recover. 
+
+- `MSALErrorServerDeclinedScopes`: Some or all scopes were declined. Decide whether to continue with only the granted scopes, or stop the sign-in process.
+
+> [!NOTE]
+> The `MSALInternalError` enum should only be used for reference and debugging. Do not try to automatically handle these errors at runtime. If your app encounters any of the errors that fall under `MSALInternalError`, you may want to show a generic user facing message explaining what happened.
+
+For example, `MSALInternalErrorBrokerResponseNotReceived` means that user didn't complete authentication and manually returned to the app. In this case, your app should show a generic error message explaining that authentication didn't complete and suggest that they try to authenticate again.
+
+The following Objective-C sample code demonstrates best practices for handling some common error conditions.
+
+```objc
+    MSALInteractiveTokenParameters *interactiveParameters = ...;
+    MSALSilentTokenParameters *silentParameters = ...;
+    
+    MSALCompletionBlock completionBlock;
+    __block __weak MSALCompletionBlock weakCompletionBlock;
+    
+    weakCompletionBlock = completionBlock = ^(MSALResult *result, NSError *error)
+    {
+        if (!error)
+        {
+            // Use result.accessToken
+            NSString *accessToken = result.accessToken;
+            return;
+        }
+        
+        if ([error.domain isEqualToString:MSALErrorDomain])
+        {
+            switch (error.code)
+            {
+                case MSALErrorInteractionRequired:
+                {
+                    // Interactive auth will be required
+                    [application acquireTokenWithParameters:interactiveParameters
+                                            completionBlock:weakCompletionBlock];
+                    
+                    break;
+                }
+                    
+                case MSALErrorServerDeclinedScopes:
+                {
+                    // These are list of granted and declined scopes.
+                    NSArray *grantedScopes = error.userInfo[MSALGrantedScopesKey];
+                    NSArray *declinedScopes = error.userInfo[MSALDeclinedScopesKey];
+                    
+                    // To continue acquiring token for granted scopes only, do the following
+                    silentParameters.scopes = grantedScopes;
+                    [application acquireTokenSilentWithParameters:silentParameters
+                                                  completionBlock:weakCompletionBlock];
+                    
+                    // Otherwise, instead, handle error fittingly to the application context
+                    break;
+                }
+                    
+                case MSALErrorServerProtectionPoliciesRequired:
+                {
+                    // Integrate the Intune SDK and call the
+                    // remediateComplianceForIdentity:silent: API.
+                    // Handle this error only if you integrated Intune SDK.
+                    // See more info here: https://aka.ms/intuneMAMSDK
+                    
+                    break;
+                }
+                    
+                case MSALErrorUserCanceled:
+                {
+                    // The user cancelled the web auth session.
+                    // You may want to ask the user to try again.
+                    // Handling of this error is optional.
+                    
+                    break;
+                }
+                    
+                case MSALErrorInternal:
+                {
+                    // Log the error, then inspect the MSALInternalErrorCodeKey
+                    // in the userInfo dictionary.
+                    // Display generic error message to the end user
+                    // More detailed information about the specific error
+                    // under MSALInternalErrorCodeKey can be found in MSALInternalError enum.
+                    NSLog(@"Failed with error %@", error);
+                    
+                    break;
+                }
+                    
+                default:
+                    NSLog(@"Failed with unknown MSAL error %@", error);
+                    
+                    break;
+            }
+            
+            return;
+        }
+        
+        // Handle no internet connection.
+        if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorNotConnectedToInternet)
+        {
+            NSLog(@"No internet connection.");
+            return;
+        }
+        
+        // Other errors may require trying again later,
+        // or reporting authentication problems to the user.
+        NSLog(@"Failed with error %@", error);
+    };
+    
+    // Acquire token silently
+    [application acquireTokenSilentWithParameters:silentParameters
+                                  completionBlock:completionBlock];
+
+     // or acquire it interactively.
+     [application acquireTokenWithParameters:interactiveParameters
+                             completionBlock:completionBlock];
+```
+
+```swift
+    let interactiveParameters: MSALInteractiveTokenParameters = ...
+    let silentParameters: MSALSilentTokenParameters = ...
+            
+    var completionBlock: MSALCompletionBlock!
+    completionBlock = { (result: MSALResult?, error: Error?) in
+                
+        if let result = result
+        {
+            // Use result.accessToken
+            let accessToken = result.accessToken
+            return
+        }
+
+        guard let error = error as NSError? else { return }
+
+        if error.domain == MSALErrorDomain, let errorCode = MSALError(rawValue: error.code)
+        {
+            switch errorCode
+            {
+                case .interactionRequired:
+                    // Interactive auth will be required
+                    application.acquireToken(with: interactiveParameters, completionBlock: completionBlock)
+
+                case .serverDeclinedScopes:
+                    let grantedScopes = error.userInfo[MSALGrantedScopesKey]
+                    let declinedScopes = error.userInfo[MSALDeclinedScopesKey]
+
+                    if let scopes = grantedScopes as? [String] {
+                        silentParameters.scopes = scopes
+                        application.acquireTokenSilent(with: silentParameters, completionBlock: completionBlock)
+                    }
+                        
+                    case .serverProtectionPoliciesRequired:
+                        // Integrate the Intune SDK and call the
+                        // remediateComplianceForIdentity:silent: API.
+                        // Handle this error only if you integrated Intune SDK.
+                        // See more info here: https://aka.ms/intuneMAMSDK
+                        break
+                        
+                    case .userCanceled:
+                       // The user cancelled the web auth session.
+                       // You may want to ask the user to try again.
+                       // Handling of this error is optional.
+                       break
+                        
+                    case .internal:
+                        // Log the error, then inspect the MSALInternalErrorCodeKey
+                        // in the userInfo dictionary.
+                        // Display generic error message to the end user
+                        // More detailed information about the specific error
+                        // under MSALInternalErrorCodeKey can be found in MSALInternalError enum.
+                        print("Failed with error \(error)");
+                        
+                    default:
+                        print("Failed with unknown MSAL error \(error)")
+            }
+        }
+                
+        // Handle no internet connection.
+        if error.domain == NSURLErrorDomain && error.code == NSURLErrorNotConnectedToInternet
+        {
+            print("No internet connection.")
+            return
+        }
+                
+        // Other errors may require trying again later,
+        // or reporting authentication problems to the user.
+        print("Failed with error \(error)");    
+    }
+   
+    // Acquire token silently
+    application.acquireToken(with: interactiveParameters, completionBlock: completionBlock)
+ 
+    // or acquire it interactively.
+    application.acquireTokenSilent(with: silentParameters, completionBlock: completionBlock)
+```
+
+---
+
+[!INCLUDE [Active directory error handling claims challenges](./includes/error-handling-and-tips/error-handling-claims-challenges.md)]
+
+MSAL for iOS and macOS allows you to request specific claims in both interactive and silent token acquisition scenarios.
+
+To request custom claims, specify `claimsRequest` in `MSALSilentTokenParameters` or `MSALInteractiveTokenParameters`.
+
+See [Request custom claims using MSAL for iOS and macOS](request-custom-claims.md) for more info.
+
+[!INCLUDE [Active directory error handling retries](./includes/error-handling-and-tips/error-handling-retries.md)]
+
+## Next steps
+
+Consider enabling [Logging in MSAL for iOS/macOS](msal-logging-ios.md) to help you diagnose and debug issues.

--- a/msal-objc-articles/msal-ios-shared-devices.md
+++ b/msal-objc-articles/msal-ios-shared-devices.md
@@ -1,0 +1,260 @@
+---
+title: Shared device mode for iOS devices
+description: Learn how to enable shared device mode to allow frontline workers to share an iOS device
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 05/16/2023
+ms.author: henrymbugua
+ms.reviewer: brandwe, akgoel23
+ms.custom: aaddev
+---
+
+# Shared device mode for iOS devices
+
+> [!IMPORTANT]
+> This feature [!INCLUDE [PREVIEW BOILERPLATE](./includes/develop-preview.md)]
+
+Frontline workers such as retail associates, flight crew members, and field service workers often use a shared mobile device to perform their work. These shared devices can present security risks if your users share their passwords or PINs, intentionally or not, to access customer and business data on the shared device.
+
+[Shared device mode](msal-shared-devices.md) allows you to configure an iOS 14 or higher device to be more easily and securely shared by employees. Employees can sign-in once and get single sign-on (SSO) to all apps that support this feature, giving them faster access to information. When they're finished with their shift or task, they can sign out of the device through any supported app that also signs them out from all apps supporting this feature, and the device is immediately ready for use by the next employee with no access to previous user's data.
+
+To take advantage of shared device mode feature, app developers and cloud device admins work together:
+
+1. **Device administrators** prepare the device to be shared by using a mobile device management (MDM) provider like Microsoft Intune. The MDM pushes the [Microsoft Authenticator app](https://support.microsoft.com/account-billing/how-to-use-the-microsoft-authenticator-app-9783c865-0308-42fb-a519-8cf666fe0acc) to the devices and turns on "Shared Mode" for each device through a profile update to the device. This Shared Mode setting is what changes the behavior of the supported apps on the device. This configuration from the MDM provider sets the shared device mode for the device and enables the [Microsoft Enterprise SSO plug-in for Apple devices](apple-sso-plugin.md) that is required for shared device mode. To learn more about SSO extensions, see the [Apple video](https://developer.apple.com/videos/play/tech-talks/301/).
+
+2. **Application developers** write a single-account app (multiple-account apps aren't supported in shared device mode) to handle the following scenario:
+
+   - Sign in a user device-wide through any supported application.
+   - Sign out a user device-wide through any supported application.
+   - Query the state of the device to determine if your application is on a device that's in shared device mode.
+   - Query the device state of the user on the device to determine if anything has changed since the last time your application was used.
+
+   Supporting shared device mode should be considered a feature upgrade for your application, and can help increase its adoption in environments where the same device is used among multiple users.
+
+   > [!IMPORTANT]
+   > [Microsoft applications](#microsoft-applications-that-support-shared-device-mode) that support shared device mode on iOS don't require any changes and just need to be installed on the device to get the benefits that come with shared device mode.
+
+## Set up device in Shared Device Mode
+
+Your device needs to be configured to support shared device mode. It must have iOS 14+ installed and be MDM-enrolled. MDM configuration also needs to enable [Microsoft Enterprise SSO plug-in for Apple devices](apple-sso-plugin.md).
+
+Microsoft Intune supports zero-touch provisioning for devices in Microsoft Entra shared device mode, which means that the device can be set up and enrolled in Intune with minimal interaction from the frontline worker. To set up device in shared device mode when using Microsoft Intune as the MDM, see [Set up enrollment for devices in Microsoft Entra shared device mode](/mem/intune/enrollment/automated-device-enrollment-shared-device-mode/).
+
+> [!IMPORTANT]
+> We are working with third-party MDMs to support shared device mode. We will update the list of third-party MDMs as they start supporting the shared device mode.
+
+## Modify your iOS application to support shared device mode
+
+Your users depend on you to ensure their data isn't leaked to another user. The following sections provide helpful signals to indicate to your application that a change has occurred and should be handled.
+
+You're responsible for checking the state of the user on the device every time your app is used, and then clearing the previous user's data. This includes if it's reloaded from the background in multi-tasking.
+
+On a user change, you should ensure both the previous user's data is cleared and that any cached data being displayed in your application is removed. We highly recommend you and your company conduct a security review process after updating your app to support shared device mode.
+
+### Detect shared device mode
+
+Detecting shared device mode is important for your application. Many applications require a change in their user experience (UX) when the application is used on a shared device. For example, your application might have a "Sign-Up" feature, which isn't appropriate for a frontline worker because they likely already have an account. You may also want to add extra security to your application's handling of data if it's in shared device mode.
+
+Use the `getDeviceInformationWithParameters:completionBlock:` API in the `MSALPublicClientApplication` to determine if an app is running on a device in shared device mode.
+
+The following code snippets show examples of using the `getDeviceInformationWithParameters:completionBlock:` API.
+
+#### Swift
+
+```swift
+application.getDeviceInformation(with: nil, completionBlock: { (deviceInformation, error) in
+
+    guard let deviceInfo = deviceInformation else {
+        return
+    }
+
+    let isSharedDevice = deviceInfo.deviceMode == .shared
+    // Change your app UX if needed
+})
+```
+
+#### Objective-C
+
+```objective-c
+[application getDeviceInformationWithParameters:nil
+                                completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+{
+    if (!deviceInformation)
+    {
+        return;
+    }
+
+    BOOL isSharedDevice = deviceInformation.deviceMode == MSALDeviceModeShared;
+    // Change your app UX if needed
+}];
+```
+
+### Get the signed-in user and determine if a user has changed on the device
+
+Another important part of supporting shared device mode is determining the state of the user on the device and clearing application data if a user has changed or if there's no user at all on the device. You're responsible for ensuring data isn't leaked to another user.
+
+You can use `getCurrentAccountWithParameters:completionBlock:` API to query the currently signed-in account on the device.
+
+#### Swift
+
+```swift
+let msalParameters = MSALParameters()
+msalParameters.completionBlockQueue = DispatchQueue.main
+
+application.getCurrentAccount(with: msalParameters, completionBlock: { (currentAccount, previousAccount, error) in
+
+    // currentAccount is the currently signed in account
+    // previousAccount is the previously signed in account if any
+})
+```
+
+#### Objective-C
+
+```objective-c
+MSALParameters *parameters = [MSALParameters new];
+parameters.completionBlockQueue = dispatch_get_main_queue();
+
+[application getCurrentAccountWithParameters:parameters
+                             completionBlock:^(MSALAccount * _Nullable account, MSALAccount * _Nullable previousAccount, NSError * _Nullable error)
+{
+    // currentAccount is the currently signed in account
+    // previousAccount is the previously signed in account if any
+}];
+```
+
+### Globally sign in a user
+
+When a device is configured as a shared device, your application can call the `acquireTokenWithParameters:completionBlock:` API to sign in the account. The account will be available globally for all eligible apps on the device after the first app signs in the account.
+
+#### Objective-C
+
+```objective-c
+MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"api://myapi/scope"] webviewParameters:[self msalTestWebViewParameters]];
+
+parameters.loginHint = self.loginHintTextField.text;
+
+[application acquireTokenWithParameters:parameters completionBlock:completionBlock];
+```
+
+### Globally sign out a user
+
+The following code removes the signed-in account and clears cached tokens from not only the app, but also from the device that's in shared device mode. It doesn't, however, clear the _data_ from your application. You must clear the data from your application, and clear any cached data your application may be displaying to the user.
+
+#### Swift
+
+```swift
+let account = .... /* account retrieved above */
+
+let signoutParameters = MSALSignoutParameters(webviewParameters: self.webViewParamaters!)
+signoutParameters.signoutFromBrowser = true // To trigger a browser signout in Safari.
+
+application.signout(with: account, signoutParameters: signoutParameters, completionBlock: {(success, error) in
+    if let error = error {
+
+        // Signout failed
+
+        return
+
+    }
+
+    // Sign out completed successfully
+
+})
+```
+
+#### Objective-C
+
+```objective-c
+MSALAccount *account = ... /* account retrieved above */;
+
+MSALSignoutParameters *signoutParameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webViewParameters];
+
+signoutParameters.signoutFromBrowser = YES; // To trigger a browser signout in Safari.
+
+[application signoutWithAccount:account signoutParameters:signoutParameters completionBlock:^(BOOL success, NSError * _Nullable error)
+
+{
+
+    if (!success)
+
+    {
+
+        // Signout failed
+
+        return;
+
+    }
+
+    // Sign out completed successfully
+
+}];
+```
+
+The [Microsoft Enterprise SSO plug-in for Apple devices](apple-sso-plugin.md) clears state only for applications. It doesn't clear state on the Safari browser. You can use the optional `signoutFromBrowser` property shown in code snippets to trigger a browser sign out in Safari. This causes the browser to briefly launch on the device.
+
+### Receive broadcast to detect global sign out initiated from other applications
+
+To receive the account change broadcast, you need to register a broadcast receiver. When an account change broadcast is received, immediately [get the signed in user and determine if a user has changed on the device](#get-the-signed-in-user-and-determine-if-a-user-has-changed-on-the-device). If a change is detected, initiate data cleanup for previously signed-in account. It's recommended to properly stop any operations and do data cleanup.
+
+The following code snippet shows how you could register a broadcast receiver.
+
+```objectivec
+NSString *const MSAL_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY = @"SHARED_MODE_CURRENT_ACCOUNT_CHANGED";
+
+- (void) registerDarwinNotificationListener 
+
+{ 
+
+   CFNotificationCenterRef center =
+
+   CFNotificationCenterGetDarwinNotifyCenter(); 
+
+   CFNotificationCenterAddObserver(center, nil,
+
+   sharedModeAccountChangedCallback,
+
+   (CFStringRef)MSAL_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY, 
+
+   nil, CFNotificationSuspensionBehaviorDeliverImmediately); 
+
+} 
+
+// CFNotificationCallbacks used specifically for Darwin notifications leave userInfo unused 
+
+void sharedModeAccountChangedCallback(CFNotificationCenterRef center, void * observer, CFStringRef name, void const * object, __unused CFDictionaryRef userInfo) 
+
+{ 
+
+    // Invoke account cleanup logic here 
+
+} 
+```
+
+For more information about the available options for `CFNotificationAddObserver` or to see the corresponding method signatures in Swift, see:
+
+- [CFNotificationAddObserver](https://developer.apple.com/documentation/corefoundation/1543316-cfnotificationcenteraddobserver?language=objc)
+- [CFNotificationCallback](https://developer.apple.com/documentation/corefoundation/cfnotificationcallback?language=objc)
+
+For iOS, your app requires a background permission to remain active in the background and listen to Darwin notifications. The background capability must be added to support a different background operation – your app may be subject to rejection from the Apple App Store if it has a background capability only to listen for Darwin notifications. If your app is already configured to complete background operations, you can add the listener as part of that operation. For more information about iOS background capabilities, see [Configuring background execution modes](https://developer.apple.com/documentation/xcode/configuring-background-execution-modes)
+
+## Microsoft applications that support shared device mode
+
+These Microsoft applications support Microsoft Entra shared device mode:
+
+- [Microsoft Teams](/microsoftteams/platform/) (in Public Preview)
+- [Microsoft Power BI Mobile](/power-bi/consumer/mobile/mobile-app-shared-device-mode) (in Public Preview)
+
+> [!IMPORTANT]
+> Public preview is provided without a service-level agreement and isn't recommended for production workloads. Some features might be unsupported or have constrained capabilities. For more information, see [Universal License Terms for Online Services](https://www.microsoft.com/licensing/terms/product/ForOnlineServices/all).
+
+## Next steps
+
+To see shared device mode in action, the following code sample on GitHub includes an example of running a frontline worker app on an iOS device in shared device mode:
+
+[MSAL iOS Swift Microsoft Graph API Sample](https://github.com/Azure-Samples/ms-identity-mobile-apple-swift-objc)

--- a/msal-objc-articles/redirect-uris-ios.md
+++ b/msal-objc-articles/redirect-uris-ios.md
@@ -1,0 +1,132 @@
+---
+title: Use redirect URIs with MSAL (iOS/macOS)
+description: Learn about the differences between the Microsoft Authentication Library for Objective-C (MSAL for iOS and macOS) and Azure AD Authentication Library for Objective-C (ADAL.ObjC) and how to migrate between them.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 01/18/2023
+ms.author: henrymbugua
+ms.reviewer: jak
+ms.custom: aaddev, has-adal-ref
+#Customer intent: As an application developer, I want to learn about how to use redirect URIs.
+---
+
+# Using redirect URIs with the Microsoft Authentication Library (MSAL) for iOS and macOS
+
+When a user authenticates, Microsoft Entra ID sends the token to the app by using the redirect URI registered with the Microsoft Entra application.
+
+The MSAL requires that the redirect URI be registered with the Microsoft Entra app in a specific format. MSAL uses a default redirect URI, if you don't specify one. The format is `msauth.[Your_Bundle_Id]://auth`.
+
+The default redirect URI format works for most apps and scenarios, including brokered authentication and system web view. Use the default format whenever possible.
+
+However, you may need to change the redirect URI for advanced scenarios, as described in the following section.
+
+## Scenarios that require a different redirect URI
+
+### Cross-app single sign-on (SSO)
+
+For the Microsoft identity platform to share tokens across apps, each app needs to have the same client ID or application ID. The client ID is the unique identifier provided when you registered your app in the Azure portal (not the application bundle ID that you register per app with Apple).
+
+The redirect URIs need to be different for each iOS app. This allows the Microsoft identity service to uniquely identify different apps that share an application ID. Each application can have multiple redirect URIs registered in the Azure portal. Each app in your suite will have a different redirect URI. For example:
+
+Given the following application registration in the Azure portal:
+
+- Client ID: `ABCDE-12345`
+- RedirectUris: `msauth.com.contoso.app1://auth`, `msauth.com.contoso.app2://auth`, `msauth.com.contoso.app3://auth`
+
+App1 uses redirect `msauth.com.contoso.app1://auth`.\
+App2 uses `msauth.com.contoso.app2://auth`.\
+App3 uses `msauth.com.contoso.app3://auth`.
+
+### Migrating from ADAL to MSAL
+
+When migrating code that used the Azure Active Directory Authentication Library (ADAL) to MSAL, you may already have a redirect URI configured for your app. You can continue using the same redirect URI as long as your ADAL app was configured to support brokered scenarios and your redirect URI satisfies the MSAL redirect URI format requirements.
+
+## MSAL redirect URI format requirements
+
+- The MSAL redirect URI must be in the form `<scheme>://host`
+
+  Where `<scheme>` is a unique string that identifies your app. It's primarily based on the Bundle Identifier of your application to guarantee uniqueness. For example, if your app's Bundle ID is `com.contoso.myapp`, your redirect URI would be in the form: `msauth.com.contoso.myapp://auth`.
+
+  If you're migrating from ADAL, your redirect URI will likely have this format: `<scheme>://[Your_Bundle_Id]`, where `scheme` is a unique string. The format will continue to work when you use MSAL.
+
+- `<scheme>` must be registered in your app's Info.plist under `CFBundleURLTypes > CFBundleURLSchemes`. In this example, Info.plist has been opened as source code:
+
+  ```xml
+  <key>CFBundleURLTypes</key>
+  <array>
+      <dict>
+          <key>CFBundleURLSchemes</key>
+          <array>
+              <string>msauth.[BUNDLE_ID]</string>
+          </array>
+      </dict>
+  </array>
+  ```
+
+MSAL will verify if your redirect URI registers correctly, and return an error if it's not.
+
+- If you want to use universal links as a redirect URI, the `<scheme>` must be `https` and doesn't need to be declared in `CFBundleURLSchemes`. Instead, configure the app and domain per Apple's instructions at [Universal Links for Developers](https://developer.apple.com/ios/universal-links/) and call the `handleMSALResponse:sourceApplication:` method of `MSALPublicClientApplication` when your application is opened through a universal link.
+
+## Use a custom redirect URI
+
+To use a custom redirect URI, pass the `redirectUri` parameter to `MSALPublicClientApplicationConfig` and pass that object to `MSALPublicClientApplication` when you initialize the object. If the redirect URI is invalid, the initializer will return `nil` and set the `redirectURIError`with additional information. For example:
+
+Objective-C:
+
+```objc
+MSALPublicClientApplicationConfig *config =
+        [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"your-client-id"
+                                                        redirectUri:@"your-redirect-uri"
+                                                        authority:authority];
+NSError *redirectURIError;
+MSALPublicClientApplication *application =
+        [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&redirectURIError];
+```
+
+Swift:
+
+```swift
+let config = MSALPublicClientApplicationConfig(clientId: "your-client-id",
+                                            redirectUri: "your-redirect-uri",
+                                              authority: authority)
+do {
+  let application = try MSALPublicClientApplication(configuration: config)
+  // continue on with application
+} catch let error as NSError {
+  // handle error here
+}
+```
+
+## Handle the URL opened event
+
+Your application should call MSAL when it receives any response through URL schemes or universal links. Call the `handleMSALResponse:sourceApplication:` method of `MSALPublicClientApplication` when your application is opened. Here's an example for custom schemes:
+
+Objective-C:
+
+```objc
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    return [MSALPublicClientApplication handleMSALResponse:url
+                                         sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+}
+```
+
+Swift:
+
+```swift
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
+}
+```
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/request-custom-claims.md
+++ b/msal-objc-articles/request-custom-claims.md
@@ -1,0 +1,128 @@
+---
+title: Request custom claims (MSAL iOS/macOS)
+description: Learn how to request custom claims.
+services: active-directory
+author: davidmu1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.workload: identity
+ms.topic: how-to
+ms.date: 01/19/2023
+ms.author: davidmu
+ms.custom: aaddev
+---
+
+# Request custom claims using MSAL for iOS and macOS
+
+OpenID Connect allows you to optionally request the return of individual claims from the UserInfo Endpoint and/or in the ID Token. A claims request is represented as a JSON object that contains a list of requested claims. See [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter) for more details.
+
+The Microsoft Authentication Library (MSAL) for iOS and macOS allows requesting specific claims in both interactive and silent token acquisition scenarios. It does so through the `claimsRequest` parameter.
+
+There are multiple scenarios where this is needed. For example:
+
+- Requesting claims outside of the standard set for your application.
+- Requesting specific combinations of the standard claims that cannot be specified using scopes for your application. For example, if an access token gets rejected because of missing claims, the application can request the missing claims using MSAL.
+
+> [!NOTE]
+> MSAL bypasses the access token cache whenever a claims request is specified. It's important to only provide `claimsRequest` parameter when additional claims are needed (as opposed to always providing same `claimsRequest` parameter in each MSAL API call).
+
+`claimsRequest` can be specified in `MSALSilentTokenParameters` and `MSALInteractiveTokenParameters`:
+
+```objc
+/*!
+ MSALTokenParameters is the base abstract class for all types of token parameters (silent and interactive).
+ */
+@interface MSALTokenParameters : NSObject
+
+/*!
+ The claims parameter that needs to be sent to authorization or token endpoint.
+ If claims parameter is passed in silent flow, access token will be skipped and refresh token will be tried.
+ */
+@property (nonatomic, nullable) MSALClaimsRequest *claimsRequest;
+
+@end
+```
+`MSALClaimsRequest` can be constructed from an NSString representation of JSON Claims request. 
+
+Objective-C:
+
+```objc
+NSError *claimsError = nil;
+MSALClaimsRequest *request = [[MSALClaimsRequest alloc] initWithJsonString:@"{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}" error:&claimsError];
+```
+
+Swift:
+
+```swift
+var requestError: NSError? = nil
+let request = MSALClaimsRequest(jsonString: "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}",
+                                        error: &requestError)
+```
+
+
+
+It can also be modified by requesting additional specific claims:
+
+Objective-C:
+
+```objc
+MSALIndividualClaimRequest *individualClaimRequest = [[MSALIndividualClaimRequest alloc] initWithName:@"custom_claim"];
+individualClaimRequest.additionalInfo = [MSALIndividualClaimRequestAdditionalInfo new];
+individualClaimRequest.additionalInfo.essential = @1;
+individualClaimRequest.additionalInfo.value = @"myvalue";
+[request requestClaim:individualClaimRequest forTarget:MSALClaimsRequestTargetIdToken error:&claimsError];
+```
+
+Swift:
+
+```swift
+let individualClaimRequest = MSALIndividualClaimRequest(name: "custom-claim")
+let additionalInfo = MSALIndividualClaimRequestAdditionalInfo()
+additionalInfo.essential = 1
+additionalInfo.value = "myvalue"
+individualClaimRequest.additionalInfo = additionalInfo
+do {
+  try request.requestClaim(individualClaimRequest, for: .idToken)
+} catch let error as NSError {
+  // handle error here  
+}
+        
+```
+
+
+
+`MSALClaimsRequest` should be then set in the token parameters and provided to one of MSAL token acquisitions APIs:
+
+Objective-C:
+
+```objc
+MSALPublicClientApplication *application = ...;
+MSALWebviewParameters *webParameters = ...;
+
+MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"user.read"]
+                                                                                  webviewParameters:webParameters];
+parameters.claimsRequest = request;
+    
+[application acquireTokenWithParameters:parameters completionBlock:completionBlock];
+```
+
+Swift:
+
+```swift
+let application: MSALPublicClientApplication!
+let webParameters: MSALWebviewParameters!
+        
+let parameters = MSALInteractiveTokenParameters(scopes: ["user.read"], webviewParameters: webParameters)
+parameters.claimsRequest = request
+        
+application.acquireToken(with: parameters) { (result: MSALResult?, error: Error?) in            ...
+
+```
+
+
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/single-sign-on-macos-ios.md
+++ b/msal-objc-articles/single-sign-on-macos-ios.md
@@ -1,0 +1,214 @@
+---
+title: Configure SSO on macOS and iOS
+description: Learn how to configure single sign on (SSO) on macOS and iOS.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 05/03/2023
+ms.author: henrymbugua
+ms.reviewer:
+ms.custom: aaddev, engagement-fy23
+---
+
+# Configure SSO on macOS and iOS
+
+The Microsoft Authentication Library (MSAL) for macOS and iOS supports single sign-on (SSO) between macOS/iOS apps and browsers. This article covers the following SSO scenarios:
+
+- [Silent SSO between multiple apps](#silent-sso-between-apps)
+
+This type of SSO works between multiple apps distributed by the same Apple Developer. It provides silent SSO (that is, the user isn't prompted for credentials) by reading refresh tokens written by other apps from the keychain, and exchanging them for access tokens silently.
+
+- [SSO through Authentication broker](#sso-through-authentication-broker-on-ios)
+
+Microsoft provides apps called brokers that enable SSO between applications from different vendors as long as the mobile device is registered with Microsoft Entra ID. This type of SSO requires a broker application be installed on the user's device.
+
+- **SSO between MSAL and Safari**
+
+SSO is achieved through the [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession?language=objc) class. It uses existing sign-in state from other apps and the Safari browser. It's not limited to apps distributed by the same Apple Developer, but it requires some user interaction.
+
+If you use the default web view in your app to sign in users, you'll get automatic SSO between MSAL-based applications and Safari. To learn more about the web views that MSAL supports, visit [Customize browsers and WebViews](customize-webviews.md).
+
+This type of SSO is currently not available on macOS. MSAL on macOS only supports WKWebView which doesn't have SSO support with Safari.
+
+> [!NOTE]
+> iOS clears session cookies right away after login due to the use of temporary browser to perform login. This browser does not share any of the session cookies. To make SSO work on iOS, KMSI must be enabled to utilize persistent cookies. 
+
+- **Silent SSO between ADAL and MSAL macOS/iOS apps**
+
+MSAL Objective-C support migration and SSO with ADAL Objective-C-based apps. The apps must be distributed by the same Apple Developer.
+
+See [SSO between ADAL and MSAL apps on macOS and iOS](sso-between-adal-msal-apps-macos-ios.md) for instructions for cross-app SSO between ADAL and MSAL-based apps.
+
+## Silent SSO between apps
+
+MSAL supports SSO sharing through iOS keychain access groups.
+
+To enable SSO across your applications, you'll need to do the following steps, which are explained in more detail below:
+
+1. Ensure that all your applications use the same Client ID or Application ID.
+1. Ensure that all of your applications share the same signing certificate from Apple so that you can share keychains.
+1. Request the same keychain entitlement for each of your applications.
+1. Tell the MSAL SDKs about the shared keychain you want us to use if it's different from the default one.
+
+### Use the same Client ID and Application ID
+
+For the Microsoft identity platform to know which applications can share tokens, those applications need to share the same Client ID or Application ID. This is the unique identifier that was provided to you when you registered your first application in the portal.
+
+The way the Microsoft identity platform tells apps that use the same Application ID apart is by their **Redirect URIs**. Each application can have multiple Redirect URIs registered in the onboarding portal. Each app in your suite will have a different redirect URI. For example:
+
+App1 Redirect URI: `msauth.com.contoso.mytestapp1://auth`  
+App2 Redirect URI: `msauth.com.contoso.mytestapp2://auth`  
+App3 Redirect URI: `msauth.com.contoso.mytestapp3://auth`
+
+The format of redirect URIs must be compatible with the format MSAL supports, which is documented in [MSAL Redirect URI format requirements](redirect-uris-ios.md#msal-redirect-uri-format-requirements).
+
+### Setup keychain sharing between applications
+
+Refer to Apple's [Adding Capabilities](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html) article to enable keychain sharing. What is important is that you decide what you want your keychain to be called and add that capability to all of your applications that will be involved in SSO.
+
+When you have the entitlements set up correctly, you'll see a `entitlements.plist` file in your project directory that contains something like this example:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.myapp.mytestapp</string>
+        <string>$(AppIdentifierPrefix)com.myapp.mycache</string>
+    </array>
+</dict>
+</plist>
+```
+
+#### Add a new keychain group
+
+Add a new keychain group to your project **Capabilities**. The keychain group should be:
+
+- `com.microsoft.adalcache` on iOS
+- `com.microsoft.identity.universalstorage` on macOS.
+
+![keychain example](media/single-sign-on-macos-ios/keychain-example.png)
+
+For more information, see [keychain groups](howto-v2-keychain-objc.md).
+
+## Configure the application object
+
+Once you have the keychain entitlement enabled in each of your applications, and you're ready to use SSO, configure `MSALPublicClientApplication` with your keychain access group as in the following example:
+
+Objective-C:
+
+```objc
+NSError *error = nil;
+MSALPublicClientApplicationConfig *configuration = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"<my-client-id>"];
+configuration.cacheConfig.keychainSharingGroup = @"my.keychain.group";
+
+MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:configuration error:&error];
+```
+
+Swift:
+
+```swift
+let config = MSALPublicClientApplicationConfig(clientId: "<my-client-id>")
+config.cacheConfig.keychainSharingGroup = "my.keychain.group"
+
+do {
+   let application = try MSALPublicClientApplication(configuration: config)
+  // continue on with application
+} catch let error as NSError {
+  // handle error here
+}
+```
+
+> [!WARNING]
+> When you share a keychain across your applications, any application can delete users or even all of the tokens across your application.
+> This is particularly impactful if you have applications that rely on tokens to do background work.
+> Sharing a keychain means that you must be very careful when your app uses Microsoft identity SDK remove operations.
+
+That's it! The Microsoft identity SDK will now share credentials across all your applications. The account list will also be shared across application instances.
+
+## SSO through Authentication broker on iOS
+
+MSAL provides support for brokered authentication with Microsoft Authenticator. Microsoft Authenticator provides SSO for Microsoft Entra registered devices, and also helps your application follow Conditional Access policies.
+
+The following steps are how you enable SSO using an authentication broker for your app:
+
+1. Register a broker compatible Redirect URI format for the application in your app's Info.plist. The broker compatible Redirect URI format is `msauth.<app.bundle.id>://auth`. Replace `<app.bundle.id>`` with your application's bundle ID. For example:
+
+   ```xml
+   <key>CFBundleURLSchemes</key>
+   <array>
+       <string>msauth.<app.bundle.id></string>
+   </array>
+   ```
+
+1. Add following schemes to your app's Info.plist under `LSApplicationQueriesSchemes`:
+
+   ```xml
+   <key>LSApplicationQueriesSchemes</key>
+   <array>
+        <string>msauthv2</string>
+        <string>msauthv3</string>
+   </array>
+   ```
+
+1. Add the following to your `AppDelegate.m` file to handle callbacks:
+
+   Objective-C:
+
+   ```objc
+   - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
+   {
+       return [MSALPublicClientApplication handleMSALResponse:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+   }
+   ```
+
+   Swift:
+
+   ```swift
+   func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+       return MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
+   }
+   ```
+
+**If you are using Xcode 11**, you should place MSAL callback into the `SceneDelegate` file instead.
+If you support both UISceneDelegate and UIApplicationDelegate for compatibility with older iOS, MSAL callback would need to be placed into both files.
+
+Objective-C:
+
+```objc
+ - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+ {
+     UIOpenURLContext *context = URLContexts.anyObject;
+     NSURL *url = context.URL;
+     NSString *sourceApplication = context.options.sourceApplication;
+
+     [MSALPublicClientApplication handleMSALResponse:url sourceApplication:sourceApplication];
+ }
+```
+
+Swift:
+
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+
+        guard let urlContext = URLContexts.first else {
+            return
+        }
+
+        let url = urlContext.url
+        let sourceApp = urlContext.options.sourceApplication
+
+        MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: sourceApp)
+    }
+```
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)

--- a/msal-objc-articles/sso-between-adal-msal-apps-macos-ios.md
+++ b/msal-objc-articles/sso-between-adal-msal-apps-macos-ios.md
@@ -1,0 +1,284 @@
+---
+title: SSO between ADAL & MSAL apps (iOS/macOS)
+description: Learn how to share SSO between ADAL and MSAL apps
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 08/28/2019
+ms.author: henrymbugua
+ms.reviewer: 
+ms.custom: aaddev, has-adal-ref
+---
+
+# How to: SSO between ADAL and MSAL apps on macOS and iOS
+
+The Microsoft Authentication Library (MSAL) for iOS can share SSO state with [ADAL Objective-C](https://github.com/AzureAD/azure-activedirectory-library-for-objc) between applications. You can migrate your apps to MSAL at your own pace, ensuring that your users will still benefit from cross-app SSO--even with a mix of ADAL and MSAL-based apps.
+
+If you're looking for guidance of setting up SSO between apps using the MSAL SDK, see [Silent SSO between multiple apps](single-sign-on-macos-ios.md#silent-sso-between-apps). This article focuses on SSO between ADAL and MSAL.
+
+The specifics implementing SSO depend on ADAL version that you're using.
+
+## ADAL 2.7.x
+
+This section covers SSO differences between MSAL and ADAL 2.7.x
+
+### Cache format
+
+ADAL 2.7.x can read the MSAL cache format. You don't need to do anything special for cross-app SSO with version ADAL 2.7.x. However, be aware of differences in account identifiers that those two libraries support.
+
+### Account identifier differences
+
+MSAL and ADAL use different account identifiers. ADAL uses UPN as its primary account identifier. MSAL uses a non-displayable account identifier that is based of an object ID and a tenant ID for AAD accounts, and a `sub` claim for other types of accounts.
+
+When you receive an `MSALAccount` object in the MSAL result, it contains an account identifier in the `identifier` property. The application should use this identifier for subsequent silent requests.
+
+In addition to `identifier`, `MSALAccount` object contains a displayable identifier called `username`. That translates to `userId` in ADAL. `username` is not considered a unique identifier and can change anytime, so it should only be used for backward compatibility scenarios with ADAL. MSAL supports cache queries using either `username` or `identifier`, where querying by `identifier` is recommended.
+
+Following table summarizes account identifier differences between ADAL and MSAL:
+
+| Account identifier                | MSAL                                                         | ADAL 2.7.x      | Older ADAL (before ADAL 2.7.x) |
+| --------------------------------- | ------------------------------------------------------------ | --------------- | ------------------------------ |
+| displayable identifier            | `username`                                                   | `userId`        | `userId`                       |
+| unique non-displayable identifier | `identifier`                                                 | `homeAccountId` | N/A                            |
+| No account id known               | Query all accounts through `allAccounts:` API in `MSALPublicClientApplication` | N/A             | N/A                            |
+
+This is the `MSALAccount` interface providing those identifiers:
+
+```objc
+@protocol MSALAccount <NSObject>
+
+/*!
+ Displayable user identifier. Can be used for UI and backward compatibility with ADAL.
+ */
+@property (readonly, nullable) NSString *username;
+
+/*!
+ Unique identifier for the account.
+ Save this for account lookups from cache at a later point.
+ */
+@property (readonly, nullable) NSString *identifier;
+
+/*!
+ Host part of the authority string used for authentication based on the issuer identifier.
+ */
+@property (readonly, nonnull) NSString *environment;
+
+/*!
+ ID token claims for the account.
+ Can be used to read additional information about the account, e.g. name
+ Will only be returned if there has been an id token issued for the client Id for the account's source tenant.
+ */
+@property (readonly, nullable) NSDictionary<NSString *, NSString *> *accountClaims;
+
+@end
+```
+
+### SSO from MSAL to ADAL
+
+If you have an MSAL app and an ADAL app, and the user first signs into the MSAL-based app, you can get SSO in the ADAL app by saving the `username` from the `MSALAccount` object and passing it to your ADAL-based app as `userId`. ADAL can then find the account information silently with the `acquireTokenSilentWithResource:clientId:redirectUri:userId:completionBlock:` API.
+
+### SSO from ADAL to MSAL
+
+If you have an MSAL app and an ADAL app, and the user first signs into the ADAL-based app, you can use ADAL user identifiers for account lookups in MSAL. This also applies when migrating from ADAL to MSAL.
+
+#### ADAL's homeAccountId
+
+ADAL 2.7.x returns the `homeAccountId` in the `ADUserInformation` object in the result via this property:
+
+```objc
+/*! Unique AAD account identifier across tenants based on user's home OID/home tenantId. */
+@property (readonly) NSString *homeAccountId;
+```
+
+`homeAccountId` in ADAL's is equivalent of `identifier` in MSAL. 
+You can save this identifier to use in MSAL for account lookups with the `accountForIdentifier:error:` API.
+
+#### ADAL's `userId`
+
+If `homeAccountId` is not available, or you only have the displayable identifier, you can use ADAL's `userId` to lookup the account in  MSAL.
+
+In MSAL, first look up an account by `username` or `identifier`. Always use `identifier` for querying if you have it, and only use `username` as a fallback. If the account is found, use the account in the `acquireTokenSilent` calls.
+
+Objective-C:
+
+```objc
+NSString *msalIdentifier = @"previously.saved.msal.account.id";
+MSALAccount *account = nil;
+    
+if (msalIdentifier)
+{
+    // If you have MSAL account id returned either from MSAL as identifier or ADAL as homeAccountId, use it
+    account = [application accountForIdentifier:@"my.account.id.here" error:nil];
+}
+else
+{
+    // Fallback to ADAL userId for migration
+    account = [application accountForUsername:@"adal.user.id" error:nil];
+}
+    
+if (!account)
+{
+  // Account not found.
+  return;
+}
+
+MSALSilentTokenParameters *silentParameters = [[MSALSilentTokenParameters alloc] initWithScopes:@[@"user.read"] account:account];
+[application acquireTokenSilentWithParameters:silentParameters completionBlock:completionBlock];
+```
+
+Swift:
+
+```swift
+        
+let msalIdentifier: String?
+var account: MSALAccount
+        
+do {
+  if let msalIdentifier = msalIdentifier {
+    account = try application.account(forIdentifier: msalIdentifier)
+  }
+  else {
+    account = try application.account(forUsername: "adal.user.id") 
+  }
+             
+  let silentParameters = MSALSilentTokenParameters(scopes: ["user.read"], account: account)          
+  application.acquireTokenSilent(with: silentParameters) {
+    (result: MSALResult?, error: Error?) in
+    // handle result
+  }  
+} catch let error as NSError {
+  // handle error or account not found
+}
+```
+
+
+
+MSAL supported account lookup APIs:
+
+```objc
+/*!
+ Returns account for the given account identifier (received from an account object returned in a previous acquireToken call)
+ 
+ @param  error      The error that occurred trying to get the accounts, if any, if you're
+                    not interested in the specific error pass in nil.
+ */
+- (nullable MSALAccount *)accountForIdentifier:(nonnull NSString *)identifier
+                                         error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+    
+/*!
+Returns account for for the given username (received from an account object returned in a previous acquireToken call or ADAL)
+    
+@param  username    The displayable value in UserPrincipleName(UPN) format
+@param  error       The error that occurred trying to get the accounts, if any, if you're
+                    not interested in the specific error pass in nil.
+*/
+- (MSALAccount *)accountForUsername:(NSString *)username
+                              error:(NSError * __autoreleasing *)error;
+```
+
+## ADAL 2.x-2.6.6
+
+This section covers SSO differences between MSAL and ADAL 2.x-2.6.6.
+
+Older ADAL versions don't natively support the MSAL cache format. However, to ensure smooth migration from ADAL to MSAL, MSAL can read the older ADAL cache format without prompting for user credentials again.
+
+Because `homeAccountId` isn't available in older ADAL versions, you'd need to look up accounts using the `username`:
+
+```objc
+/*!
+ Returns account for for the given username (received from an account object returned in a previous acquireToken call or ADAL)
+
+ @param  username    The displayable value in UserPrincipleName(UPN) format
+ @param  error       The error that occurred trying to get the accounts, if any.  If you're not interested in the specific error pass in nil.
+ */
+- (MSALAccount *)accountForUsername:(NSString *)username
+                              error:(NSError * __autoreleasing *)error;
+```
+
+For example:
+
+Objective-C:
+
+
+```objc
+MSALAccount *account = [application accountForUsername:@"adal.user.id" error:nil];;
+MSALSilentTokenParameters *silentParameters = [[MSALSilentTokenParameters alloc] initWithScopes:@[@"user.read"] account:account];
+[application acquireTokenSilentWithParameters:silentParameters completionBlock:completionBlock];
+```
+
+Swift:
+
+```swift
+do {
+  let account = try application.account(forUsername: "adal.user.id")          
+  let silentParameters = MSALSilentTokenParameters(scopes: ["user.read"], account: account)
+  application.acquireTokenSilent(with: silentParameters) { 
+    (result: MSALResult?, error: Error?) in
+    // handle result
+  }   
+} catch let error as NSError { 
+  // handle error or account not found
+}
+```
+
+
+
+Alternatively, you can read all of the accounts, which will also read account information from ADAL:
+
+Objective-C:
+
+```objc
+NSArray *accounts = [application allAccounts:nil];
+    
+if ([accounts count] == 0)
+{
+  // No account found.
+  return; 
+}
+if ([accounts count] > 1)
+{
+  // You might want to display an account picker to user in actual application
+  // For this sample we assume there's only ever one account in cache
+  return;
+}
+    ``
+MSALSilentTokenParameters *silentParameters = [[MSALSilentTokenParameters alloc] initWithScopes:@[@"user.read"] account:accounts[0]];
+[application acquireTokenSilentWithParameters:silentParameters completionBlock:completionBlock];
+```
+
+Swift:
+
+```swift
+      
+do {
+  let accounts = try application.allAccounts()
+  if accounts.count == 0 {
+    // No account found.
+    return
+  }
+  if accounts.count > 1 {
+    // You might want to display an account picker to user in actual application
+    // For this sample we assume there's only ever one account in cache
+    return
+  }
+  
+  let silentParameters = MSALSilentTokenParameters(scopes: ["user.read"], account: accounts[0])
+  application.acquireTokenSilent(with: silentParameters) {
+    (result: MSALResult?, error: Error?) in
+    // handle result or error  
+  }  
+} catch let error as NSError { 
+  // handle error
+}
+```
+
+
+
+## Next steps
+
+Learn more about [Authentication flows and application scenarios](authentication-flows-app-scenarios.md)


### PR DESCRIPTION
This PR migrates the MSAL iOS wiki from GitHub and consolidates the content with that living in the official Microsoft identity platform docs such as https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-differences-ios-macos 