### PR TITLE
Update macOS keychain access group

### DIFF
--- a/msal-objc-articles/howto-v2-keychain-objc.md
+++ b/msal-objc-articles/howto-v2-keychain-objc.md
@@ -32,9 +32,7 @@ On iOS, add the `com.microsoft.adalcache` keychain group to your app's entitleme
 
 MSAL on macOS uses `com.microsoft.identity.universalstorage` access group by default.
 
-Due to macOS keychain limitations, MSAL's `access group` doesn't directly translate to the keychain access group attribute (see [kSecAttrAccessGroup](https://developer.apple.com/documentation/security/ksecattraccessgroup?language=objc)) on macOS 10.14 and earlier. However, it behaves similarly from an SSO perspective by ensuring that multiple applications distributed by the same Apple developer can have silent SSO.
-
-On macOS 10.15 onwards (macOS Catalina), MSAL uses keychain access group attribute to achieve silent SSO, similarly to iOS.
+On MacOS, add the `com.microsoft.identity.universalstorage` keychain group to your app's entitlement in XCode under **Project settings** > **Capabilities** > **Keychain sharing**, similarly to iOS.
 
 ## Custom keychain access group
 


### PR DESCRIPTION
Remove specific details about macOS 14 because minimum version for MSAL Objective-C is macOS 15