### PR TITLE
Add MDMs that support shared device mode

### DIFF
--- a/msal-objc-articles/shared-devices-ios.md
+++ b/msal-objc-articles/shared-devices-ios.md
@@ -228,9 +228,14 @@ These Microsoft applications support Microsoft Entra shared device mode:
 - [Microsoft Power BI Mobile](/power-bi/consumer/mobile/mobile-app-shared-device-mode)
 - [Microsoft Edge](/microsoft-edge/)
 
-
 > [!IMPORTANT]
 > Public preview is provided without a service-level agreement and isn't recommended for production workloads. Some features might be unsupported or have constrained capabilities. For more information, see [Universal License Terms for Online Services](https://www.microsoft.com/licensing/terms/product/ForOnlineServices/all).
+
+## Third-party MDMs that support shared device mode
+
+These third-party Mobile Device Management (MDM) providers support Microsoft Entra shared device mode:
+
+- [Jamf](https://learn.jamf.com/en-US/bundle/jamf-pro-release-notes-current/page/New_Features_and_Enhancements.html#ariaid-title5)
 
 ## Next steps
 


### PR DESCRIPTION
This pull request includes an update to the `msal-objc-articles/shared-devices-ios.md` file to add information about third-party Mobile Device Management (MDM) providers that support Microsoft Entra shared device mode.

Documentation updates:

* Added a new section titled "Third-party MDMs that support shared device mode" with a list of supported third-party MDM providers, including a link to Jamf's release notes.