### PR TITLE
Remove Xamarin

### DIFF
--- a/msal-objc-articles/migrate-objc-adal-msal.md
+++ b/msal-objc-articles/migrate-objc-adal-msal.md
@@ -181,11 +181,7 @@ In ADAL, you create separate instances of `ADAuthenticationContext` for each ten
 
 ## SSO in partnership with other SDKs
 
-MSAL for iOS can achieve SSO via a unified cache with the following SDKs:
-
-- ADAL Objective-C 2.7.x+
-- MSAL.NET for Xamarin 2.4.x+
-- ADAL.NET for Xamarin 4.4.x+
+MSAL for iOS can achieve SSO via a unified cache with ADAL Objective-C 2.7.x+.
 
 SSO is achieved via iOS keychain sharing and is only available between apps published from the same Apple Developer account.
 


### PR DESCRIPTION
Xamarin products have been out of support since 1st May 2024, and the [docs](https://learn.microsoft.com/previous-versions/xamarin) are archived. Xamarin products have since been rebranded to .NET, hence I've removed Xamarin as a supported product.