### PR TITLE
Fix busted doc links in MSAL iOS/MacOS docs

### DIFF
--- a/msal-objc-articles/install-and-configure-msal.md
+++ b/msal-objc-articles/install-and-configure-msal.md
@@ -8,9 +8,9 @@ ms.service: msal
 ms.subservice: msal-ios-mac
 ms.topic: conceptual
 ms.workload: identity
-ms.date: 09/22/2023
+ms.date: 03/11/2024
 ms.author: dmwendia
-ms.reviewer: oldalton, brianmel
+ms.reviewer: oldalton
 ms.custom: aaddev
 ---
 
@@ -100,7 +100,7 @@ github "AzureAD/microsoft-authentication-library-for-objc" == <latest_released_v
   ```
   $(SRCROOT)/Carthage/Build/iOS/MSAL.framework
   ```
-  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
+  This script works around an [App Store submission bug](http://www.openradar.me/) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
 
 With the debug information copied into the built products directory, Xcode will be able to symbolicate the stack trace whenever you stop at a breakpoint. This will also enable you to step through third-party code in the debugger.
 

--- a/msal-objc-articles/migrate-objc-adal-msal.md
+++ b/msal-objc-articles/migrate-objc-adal-msal.md
@@ -196,7 +196,7 @@ MSAL on iOS also supports two other types of SSO:
 
 ## Intune MAM SDK
 
-The [Intune MAM SDK](/intune/app-sdk-get-started) supports MSAL for iOS starting with version [11.1.2](https://github.com/msintuneappsdk/ms-intune-app-sdk-ios/releases/tag/11.1.2)
+The [Intune MAM SDK](/mem/intune-service/developer/app-sdk-android-phase3) supports MSAL for iOS starting with version [11.1.2](https://github.com/msintuneappsdk/ms-intune-app-sdk-ios/releases/tag/11.1.2)
 
 ## MSAL and ADAL in the same app
 


### PR DESCRIPTION
This pull request includes updates to the `msal-objc-articles` related to MSAL for iOS. The most important changes include correcting a link and updating the reference URL for the Intune MAM SDK.

Documentation updates:
* [`msal-objc-articles/install-and-configure-msal.md`](diffhunk://#diff-c8dd21aefd006b9c1148f325cc3bc8f2ca3e87879c30d5a3ae672e6bd7da991eL103-R103): Corrected the App Store submission bug link to a more general URL.
* [`msal-objc-articles/migrate-objc-adal-msal.md`](diffhunk://#diff-0fb2daf16a93be3567cb499b8a0759a55e1b8c212858c56436e70a5693b11ebfL199-R199): Updated the Intune MAM SDK reference URL to point to the correct documentation page.