### PR TITLE
Revise device registration steps for Shared Device Mode

### DIFF
--- a/msal-objc-articles/set-up-ios-device-shared-mode.md
+++ b/msal-objc-articles/set-up-ios-device-shared-mode.md
@@ -62,15 +62,15 @@ iOS settings:
 To configure the Authenticator app settings and register the device with Entra ID, the Cloud Device Administrator in a tenant should follow these steps:
 
 1. Launch the Authenticator App.
-1. On the Shared Device Mode manual setup UI, enter the organizational email and select “Register as Shared Device**, as shown:
+1. The App should automatically start registering the device (as long as the SSO profile is already on the device) without any user interaction needed. If it doesn't try closing the app and validating the SSO payload is on the devcie and then re-open the Authenticator app:
 
     :::image type="content" source="media/share-device-mode/microsoft-authenticator-set-up-shared-device-mode.png " alt-text="Screenshot showing the device registration screen in app":::
 
-1. The Authenticator app prompts you to provide your credentials, as shown:
+1. If The Authenticator app prompts you to provide your credentials, as shown (please close the app and validate the SSO profile has been installed, DO NOT enter any email addess):
 
     :::image type="content" source="media/share-device-mode/cloud-administrator-provide-credentials.png " alt-text="Screenshot of the sign-in page in Authenticator app":::
 
-1. Upon providing credentials, the device is successfully set in shared device mode.
+1. f teh registration successed, the device is successfully set in shared device mode.
 
    :::image type="content" source="media/share-device-mode/shared-device-mode-setup-successful.png " alt-text="Screenshot of a successful shared device mode setup in the Authenticator app":::
 

--- a/msal-objc-articles/set-up-ios-device-shared-mode.md
+++ b/msal-objc-articles/set-up-ios-device-shared-mode.md
@@ -66,7 +66,7 @@ To configure the Authenticator app settings and register the device with Entra I
 
     :::image type="content" source="media/share-device-mode/microsoft-authenticator-set-up-shared-device-mode.png " alt-text="Screenshot showing the device registration screen in app":::
 
-1. If The Authenticator app prompts you to provide your credentials, as shown (please close the app and validate the SSO profile has been installed, DO NOT enter any email addess):
+1. If the Authenticator app prompts you to provide your credentials, as shown, close the app and validate that the SSO profile has been installed. Do not enter an email address.
 
     :::image type="content" source="media/share-device-mode/cloud-administrator-provide-credentials.png " alt-text="Screenshot of the sign-in page in Authenticator app":::
 

--- a/msal-objc-articles/set-up-ios-device-shared-mode.md
+++ b/msal-objc-articles/set-up-ios-device-shared-mode.md
@@ -62,7 +62,7 @@ iOS settings:
 To configure the Authenticator app settings and register the device with Entra ID, the Cloud Device Administrator in a tenant should follow these steps:
 
 1. Launch the Authenticator App.
-1. The App should automatically start registering the device (as long as the SSO profile is already on the device) without any user interaction needed. If it doesn't try closing the app and validating the SSO payload is on the devcie and then re-open the Authenticator app:
+1. The App should automatically start registering the device (as long as the SSO profile is already on the device) without any user interaction needed. If it doesn't, try closing the app and validating that the SSO payload is on the device. Then open the Authenticator app again:
 
     :::image type="content" source="media/share-device-mode/microsoft-authenticator-set-up-shared-device-mode.png " alt-text="Screenshot showing the device registration screen in app":::
 
@@ -70,7 +70,7 @@ To configure the Authenticator app settings and register the device with Entra I
 
     :::image type="content" source="media/share-device-mode/cloud-administrator-provide-credentials.png " alt-text="Screenshot of the sign-in page in Authenticator app":::
 
-1. f teh registration successed, the device is successfully set in shared device mode.
+1. If the registration succeeded, the device is successfully set in shared device mode.
 
    :::image type="content" source="media/share-device-mode/shared-device-mode-setup-successful.png " alt-text="Screenshot of a successful shared device mode setup in the Authenticator app":::
 


### PR DESCRIPTION
Updated instructions for registering a device in Shared Device Mode, including automatic registration and credential prompts. (current steps are WRONG and mislead customers) However, the screenshots need to be updated. please contact me directly (CAHER) to further discuss I can show you a video from last week on how the actual procedure looks like

<img width="1194" height="895" alt="image" src="https://github.com/user-attachments/assets/5c5b0442-8e2f-43e9-bcf1-315671d431f5" />


<img width="1191" height="834" alt="SDMCorrectFlow" src="https://github.com/user-attachments/assets/d713b772-4fd2-47d1-9265-b7fa0d3058a9" />
